### PR TITLE
Normalize plugin scaffold names

### DIFF
--- a/src/datapipeline/services/scaffold/plugin.py
+++ b/src/datapipeline/services/scaffold/plugin.py
@@ -3,6 +3,25 @@ from pathlib import Path
 
 from ..constants import COMPOSED_LOADER_EP
 
+_RESERVED_PACKAGE_NAMES = {"datapipeline"}
+
+
+def _normalized_package_name(dist_name: str) -> str:
+    package_name = dist_name.replace("-", "_")
+    if package_name in _RESERVED_PACKAGE_NAMES:
+        print(
+            "❗ `datapipeline` is reserved for the core package. "
+            "Choose a different plugin name."
+        )
+        raise SystemExit(1)
+    if not package_name.isidentifier():
+        print(
+            "❗ Plugin names must be valid Python identifiers once hyphens are replaced "
+            "with underscores."
+        )
+        raise SystemExit(1)
+    return package_name
+
 
 def scaffold_plugin(name: str, outdir: Path) -> None:
     target = (outdir / name).absolute()
@@ -11,13 +30,20 @@ def scaffold_plugin(name: str, outdir: Path) -> None:
         raise SystemExit(1)
     import shutil
 
+    package_name = _normalized_package_name(name)
     skeleton_ref = files("datapipeline") / "templates" / "plugin_skeleton"
     with as_file(skeleton_ref) as skeleton_dir:
         shutil.copytree(skeleton_dir, target)
     pkg_dir = target / "src" / "{{PACKAGE_NAME}}"
-    pkg_dir.rename(target / "src" / name)
+    pkg_dir.rename(target / "src" / package_name)
+    replacements = {
+        "{{PACKAGE_NAME}}": package_name,
+        "{{DIST_NAME}}": name,
+        "{{COMPOSED_LOADER_EP}}": COMPOSED_LOADER_EP,
+    }
     for p in (target / "pyproject.toml", target / "README.md"):
-        text = p.read_text().replace("{{PACKAGE_NAME}}", name)
-        text = text.replace("{{COMPOSED_LOADER_EP}}", COMPOSED_LOADER_EP)
+        text = p.read_text()
+        for placeholder, value in replacements.items():
+            text = text.replace(placeholder, value)
         p.write_text(text)
     print(f"✨ Created plugin skeleton at {target}")

--- a/src/datapipeline/templates/plugin_skeleton/README.md
+++ b/src/datapipeline/templates/plugin_skeleton/README.md
@@ -1,10 +1,10 @@
-# {{PACKAGE_NAME}}
+# {{DIST_NAME}}
 
 Minimal plugin skeleton for the Jerry Thomas (datapipeline) framework.
 
 Quick start
 - Initialize a plugin (already done if you’re reading this here):
-- `jerry plugin init --name {{PACKAGE_NAME}}`
+- `jerry plugin init --name {{DIST_NAME}}`
 - Add a source via CLI (transport-specific placeholders are scaffolded):
   - File data: `jerry source add -p <provider> -d <dataset> -t fs -f <csv|json|json-lines>`
   - URL data: `jerry source add -p <provider> -d <dataset> -t url -f <json|json-lines|csv>`

--- a/src/datapipeline/templates/plugin_skeleton/pyproject.toml
+++ b/src/datapipeline/templates/plugin_skeleton/pyproject.toml
@@ -3,9 +3,9 @@ requires = ["setuptools>=61.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "{{PACKAGE_NAME}}"
+name = "{{DIST_NAME}}"
 version = "0.0.1"
-description = "A DataPipeline plugin for the {{PACKAGE_NAME}} domain"
+description = "A DataPipeline plugin for the {{DIST_NAME}} domain"
 dependencies = [
   "jerry-thomas>=0.2.0",
 ]

--- a/tests/test_scaffold_plugin.py
+++ b/tests/test_scaffold_plugin.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+
+import pytest
+
+from datapipeline.services.scaffold.plugin import scaffold_plugin
+
+
+def test_scaffold_plugin_normalizes_hyphenated_name(tmp_path: Path) -> None:
+    scaffold_plugin("test-datapipeline", tmp_path)
+
+    plugin_root = tmp_path / "test-datapipeline"
+    assert (plugin_root / "src" / "test_datapipeline").is_dir()
+
+    pyproject = (plugin_root / "pyproject.toml").read_text()
+    assert 'name = "test-datapipeline"' in pyproject
+
+    readme = (plugin_root / "README.md").read_text()
+    assert "jerry plugin init --name test-datapipeline" in readme
+
+
+@pytest.mark.parametrize("name", ["data pipeline", "datapipeline"])
+def test_scaffold_plugin_rejects_disallowed_names(name: str, tmp_path: Path) -> None:
+    with pytest.raises(SystemExit) as exc:
+        scaffold_plugin(name, tmp_path)
+
+    assert exc.value.code == 1


### PR DESCRIPTION
## Summary
- normalize plugin package directories by converting hyphens to underscores and blocking reserved names
- update plugin skeleton templates to use separate placeholders for distribution and package identifiers
- add tests covering hyphenated plugin names and invalid name rejection

## Testing
- pytest tests/test_scaffold_plugin.py

------
https://chatgpt.com/codex/tasks/task_e_68ff26c5e5c8833182ff5a505a3edbbf