### PR TITLE
Unify serve output views and dedupe stage preview streams

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -18,15 +18,15 @@ All commands that take a project accept either `--project <path/to/project.yaml>
   - Stage 8: vectors + postprocess transforms
   - Use `--log-level DEBUG` for progress bars; the default is typically `INFO` (or `jerry.yaml.shared.log_level` when set).
   - Ensures build artifacts are current before streaming; the build step only runs when the configuration hash changes unless you pass `--stage` 0-6 (auto-skip) or opt out with `--skip-build`. Stage 6 may require scaler artifacts.
-- `jerry serve --project <project.yaml> --output-transport stdout --output-format jsonl --output-view flat|raw|numeric --output-encoding <codec> --limit N [--log-level LEVEL] [--visuals ...] [--progress ...] [--run name]`
+- `jerry serve --project <project.yaml> --output-transport stdout --output-format jsonl --output-view flat|raw|values --output-encoding <codec> --limit N [--log-level LEVEL] [--visuals ...] [--progress ...] [--run name]`
   - Applies postprocess transforms and optional dataset split before emitting.
   - Use `--output-transport fs --output-format jsonl --output-directory build/serve` (or `csv`, `pickle`) to write artifacts to disk instead of stdout; files land under `<output-directory>/<run_name>/`.
   - `--output-view` controls payload shape:
     - `flat`: key + kind + flattened fields
     - `raw`: key + kind + raw object
-    - `numeric`: key + kind + ordered numeric values
+    - `values`: key + kind + ordered values (mixed primitive types allowed)
   - If `--output-view` is omitted: `print/jsonl -> raw`, `csv/pickle -> flat`.
-  - `csv` supports `flat` and `numeric` views.
+  - `csv` supports `flat` and `values` views.
   - `--output-encoding` applies to fs `jsonl`/`csv` outputs (default `utf-8`).
   - Set `--log-level DEBUG` (or set your serve task `log_level: DEBUG`) to reuse the tqdm progress bars when previewing stages.
   - When multiple serve tasks exist, add `--run val` (task name or filename stem) to target a single config; otherwise every enabled task is executed sequentially.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -18,12 +18,16 @@ All commands that take a project accept either `--project <path/to/project.yaml>
   - Stage 8: vectors + postprocess transforms
   - Use `--log-level DEBUG` for progress bars; the default is typically `INFO` (or `jerry.yaml.shared.log_level` when set).
   - Ensures build artifacts are current before streaming; the build step only runs when the configuration hash changes unless you pass `--stage` 0-6 (auto-skip) or opt out with `--skip-build`. Stage 6 may require scaler artifacts.
-- `jerry serve --project <project.yaml> --output-transport stdout --output-format jsonl --limit N [--log-level LEVEL] [--visuals ...] [--progress ...] [--run name]`
+- `jerry serve --project <project.yaml> --output-transport stdout --output-format jsonl --output-view flat|raw|numeric --output-encoding <codec> --limit N [--log-level LEVEL] [--visuals ...] [--progress ...] [--run name]`
   - Applies postprocess transforms and optional dataset split before emitting.
-  - Use `--output-transport fs --output-format jsonl --output-directory build/serve` (or `csv`, `pickle`, etc.) to write artifacts to disk instead of stdout; files land under `<output-directory>/<run_name>/`.
-- `--output-payload vector` emits only the vector payload with features/targets
-  flattened into schema-ordered lists (no identifier keys) when you don't need
-  the group key or metadata. Default is `sample`.
+  - Use `--output-transport fs --output-format jsonl --output-directory build/serve` (or `csv`, `pickle`) to write artifacts to disk instead of stdout; files land under `<output-directory>/<run_name>/`.
+  - `--output-view` controls payload shape:
+    - `flat`: key + kind + flattened fields
+    - `raw`: key + kind + raw object
+    - `numeric`: key + kind + ordered numeric values
+  - If `--output-view` is omitted: `print/jsonl -> raw`, `csv/pickle -> flat`.
+  - `csv` supports `flat` and `numeric` views.
+  - `--output-encoding` applies to fs `jsonl`/`csv` outputs (default `utf-8`).
   - Set `--log-level DEBUG` (or set your serve task `log_level: DEBUG`) to reuse the tqdm progress bars when previewing stages.
   - When multiple serve tasks exist, add `--run val` (task name or filename stem) to target a single config; otherwise every enabled task is executed sequentially.
   - Argument precedence follows the order described under _Configuration & Resolution Order_.

--- a/docs/config.md
+++ b/docs/config.md
@@ -71,7 +71,7 @@ keep: train # select active split label (null disables filtering)
 output:
   transport: stdout # stdout | fs
   format: print # print | jsonl | csv | pickle
-  # view: raw # optional; flat | raw | numeric (default: print/jsonl->raw, csv/pickle->flat)
+  # view: raw # optional; flat | raw | values (default: print/jsonl->raw, csv/pickle->flat)
   # encoding: utf-8 # fs jsonl/csv only
 limit: 100 # cap vectors per serve run (null = unlimited)
 throttle_ms: null # milliseconds to sleep between emitted vectors
@@ -112,7 +112,7 @@ serve:
   output:
     transport: stdout
     format: print # print | jsonl | csv | pickle
-    # view: raw # optional; flat | raw | numeric (default: print/jsonl->raw, csv/pickle->flat)
+    # view: raw # optional; flat | raw | values (default: print/jsonl->raw, csv/pickle->flat)
     # encoding: utf-8 # fs jsonl/csv only
     # directory: artifacts/serve # Required when transport=fs
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -70,7 +70,9 @@ name: train # defaults to filename stem when omitted
 keep: train # select active split label (null disables filtering)
 output:
   transport: stdout # stdout | fs
-  format: print # print | jsonl | json | csv | pickle
+  format: print # print | jsonl | csv | pickle
+  # view: raw # optional; flat | raw | numeric (default: print/jsonl->raw, csv/pickle->flat)
+  # encoding: utf-8 # fs jsonl/csv only
 limit: 100 # cap vectors per serve run (null = unlimited)
 throttle_ms: null # milliseconds to sleep between emitted vectors
 # Optional overrides:
@@ -81,6 +83,7 @@ throttle_ms: null # milliseconds to sleep between emitted vectors
 
 - Each serve task lives alongside artifact tasks under `paths.tasks`. Files are independent—no special directory structure required.
 - `output`, `limit`, `throttle_ms`, and `log_level` provide defaults for `jerry serve`; CLI flags still win per invocation (see _Configuration & Resolution Order_). For filesystem outputs, set `transport: fs`, `directory: /path/to/root`, and omit file names—each run automatically writes to `<directory>/<run_name>/<run_name>.<ext>` unless you override the entire `output` block with a custom `filename`.
+- `output.encoding` is supported for fs `jsonl`/`csv` outputs (default `utf-8`); it is invalid for `stdout` and `pickle`.
 - Override `keep` (and other fields) per invocation via `jerry serve ... --keep val` etc.
 - Visuals backend: set `visuals: AUTO|TQDM|RICH|OFF` in the task or use `--visuals`. Pair with `progress: AUTO|SPINNER|BARS|OFF` or `--progress` to control progress layouts.
 - Add additional `kind: serve` files to the tasks directory for other splits (val/test/etc.); `jerry serve` runs each enabled file unless you pass `--run <name>`.
@@ -108,7 +111,9 @@ serve:
   stage: null
   output:
     transport: stdout
-    format: print # print | jsonl | json | csv | pickle
+    format: print # print | jsonl | csv | pickle
+    # view: raw # optional; flat | raw | numeric (default: print/jsonl->raw, csv/pickle->flat)
+    # encoding: utf-8 # fs jsonl/csv only
     # directory: artifacts/serve # Required when transport=fs
 
 build:

--- a/docs/dataflow.md
+++ b/docs/dataflow.md
@@ -13,7 +13,7 @@ jerry.yaml: default_dataset
         -> contracts/*.yaml: source: <sources.id>, id: <stream_id>
           -> dataset.yaml: record_stream: <contracts.id>, field: <record_field>
             -> jerry serve
-              -> runs/<run_id>/dataset/<split>.jsonl|json|csv|...
+              -> runs/<run_id>/dataset/<split>.jsonl|csv|...
 ```
 
 ## 1) Workspace selects dataset project
@@ -126,7 +126,7 @@ Screenshot slot:
 Run command:
 
 ```bash
-jerry serve --output-transport fs --output-format json --output-directory vectors
+jerry serve --output-transport fs --output-format jsonl --output-directory vectors
 ```
 
 Output layout:
@@ -135,9 +135,9 @@ Output layout:
 vectors/
   runs/<run_id>/
     dataset/
-      test.json
-      train.json
-      val.json
+      test.jsonl
+      train.jsonl
+      val.jsonl
 ```
 
 Expected behavior:

--- a/src/datapipeline/cli/app.py
+++ b/src/datapipeline/cli/app.py
@@ -27,6 +27,7 @@ from datapipeline.config.workspace import (
 from datapipeline.config.options import (
     OUTPUT_FORMATS,
     OUTPUT_TRANSPORTS,
+    OUTPUT_VIEWS,
     PROGRESS_CHOICES,
     SOURCE_FS_FORMATS,
     SOURCE_TRANSPORTS,
@@ -326,16 +327,20 @@ def main() -> None:
     p_serve.add_argument(
         "--output-format",
         choices=OUTPUT_FORMATS,
-        help="output format (print/jsonl/json/csv/pickle) for serve runs",
-    )
-    p_serve.add_argument(
-        "--output-payload",
-        choices=["sample", "vector"],
-        help="payload structure: full sample (default) or vector-only body",
+        help="output format (print/jsonl/csv/pickle) for serve runs",
     )
     p_serve.add_argument(
         "--output-directory",
         help="destination directory when using fs transport",
+    )
+    p_serve.add_argument(
+        "--output-encoding",
+        help="text encoding for fs jsonl/csv outputs (default: utf-8)",
+    )
+    p_serve.add_argument(
+        "--output-view",
+        choices=OUTPUT_VIEWS,
+        help="output representation view (flat/raw/numeric); csv supports flat|numeric",
     )
     p_serve.add_argument(
         "--keep",
@@ -726,8 +731,9 @@ def main() -> None:
             stage=getattr(args, "stage", None),
             output_transport=getattr(args, "output_transport", None),
             output_format=getattr(args, "output_format", None),
-            output_payload=getattr(args, "output_payload", None),
             output_directory=getattr(args, "output_directory", None),
+            output_encoding=getattr(args, "output_encoding", None),
+            output_view=getattr(args, "output_view", None),
             skip_build=getattr(args, "skip_build", False),
             cli_log_level=cli_level_arg,
             base_log_level=base_level_name,

--- a/src/datapipeline/cli/app.py
+++ b/src/datapipeline/cli/app.py
@@ -340,7 +340,7 @@ def main() -> None:
     p_serve.add_argument(
         "--output-view",
         choices=OUTPUT_VIEWS,
-        help="output representation view (flat/raw/numeric); csv supports flat|numeric",
+        help="output representation view (flat/raw/values); csv supports flat|values",
     )
     p_serve.add_argument(
         "--keep",

--- a/src/datapipeline/cli/commands/run.py
+++ b/src/datapipeline/cli/commands/run.py
@@ -24,11 +24,11 @@ logger = logging.getLogger(__name__)
 
 _OUTPUT_MATRIX_HELP = (
     "Valid output combinations:\n"
-    "  stdout: format=print|jsonl, view=flat|raw|numeric\n"
+    "  stdout: format=print|jsonl, view=flat|raw|values\n"
     "          encoding is not supported\n"
-    "  fs:     format=jsonl|csv|pickle, view=flat|raw|numeric\n"
+    "  fs:     format=jsonl|csv|pickle, view=flat|raw|values\n"
     "          encoding is supported only for jsonl/csv (default utf-8)\n"
-    "          csv supports view=flat|numeric\n"
+    "          csv supports view=flat|values\n"
 )
 
 

--- a/src/datapipeline/cli/commands/run.py
+++ b/src/datapipeline/cli/commands/run.py
@@ -3,6 +3,8 @@ import logging
 from pathlib import Path
 from typing import Optional
 
+from pydantic import ValidationError
+
 from datapipeline.cli.commands.build import run_build_if_needed
 from datapipeline.cli.commands.run_config import (
     RunEntry,
@@ -19,6 +21,15 @@ from datapipeline.pipeline.artifacts import StageDemand, required_artifacts_for
 from datapipeline.services.path_policy import resolve_workspace_path
 
 logger = logging.getLogger(__name__)
+
+_OUTPUT_MATRIX_HELP = (
+    "Valid output combinations:\n"
+    "  stdout: format=print|jsonl, view=flat|raw|numeric\n"
+    "          encoding is not supported\n"
+    "  fs:     format=jsonl|csv|pickle, view=flat|raw|numeric\n"
+    "          encoding is supported only for jsonl/csv (default utf-8)\n"
+    "          csv supports view=flat|numeric\n"
+)
 
 
 def _profile_debug_payload(profile) -> dict[str, object]:
@@ -45,7 +56,8 @@ def _profile_debug_payload(profile) -> dict[str, object]:
         "output": {
             "transport": profile.output.transport,
             "format": profile.output.format,
-            "payload": profile.output.payload,
+            "view": profile.output.view,
+            "encoding": profile.output.encoding,
             "destination": str(profile.output.destination)
             if profile.output.destination
             else None,
@@ -80,13 +92,18 @@ def _build_cli_output_config(
     transport: Optional[str],
     fmt: Optional[str],
     directory: Optional[str],
-    payload: Optional[str],
+    output_encoding: Optional[str] = None,
     workspace=None,
-) -> tuple[ServeOutputConfig | None, Optional[str]]:
-    payload_style = _normalize_payload(payload)
-
-    if transport is None and fmt is None and directory is None:
-        return None, payload_style
+    view: Optional[str] = None,
+) -> ServeOutputConfig | None:
+    if (
+        transport is None
+        and fmt is None
+        and directory is None
+        and view is None
+        and output_encoding is None
+    ):
+        return None
 
     if not transport or not fmt:
         logger.error("--output-transport and --output-format must be provided together")
@@ -102,37 +119,32 @@ def _build_cli_output_config(
             directory,
             workspace.root if workspace is not None else None,
         )
-        return (
-            ServeOutputConfig(
+        try:
+            return ServeOutputConfig(
                 transport="fs",
                 format=fmt,
+                view=view,
+                encoding=output_encoding,
                 directory=resolved_directory,
-                payload=payload_style or "sample",
-            ),
-            None,
-        )
+            )
+        except ValidationError as exc:
+            logger.error("Invalid output configuration: %s", exc.errors()[0]["msg"])
+            logger.error(_OUTPUT_MATRIX_HELP)
+            raise SystemExit(2) from exc
     if directory:
         logger.error("--output-directory is only valid when --output-transport=fs")
         raise SystemExit(2)
-    return (
-        ServeOutputConfig(
+    try:
+        return ServeOutputConfig(
             transport="stdout",
             format=fmt,
-            payload=payload_style or "sample",
-        ),
-        None,
-    )
-
-
-def _normalize_payload(payload: Optional[str]) -> Optional[str]:
-    if payload is None:
-        return None
-    payload_style = payload.lower()
-    if payload_style not in {"sample", "vector"}:
-        logger.error("--output-payload must be 'sample' or 'vector'")
-        raise SystemExit(2)
-    return payload_style
-
+            view=view,
+            encoding=output_encoding,
+        )
+    except ValidationError as exc:
+        logger.error("Invalid output configuration: %s", exc.errors()[0]["msg"])
+        logger.error(_OUTPUT_MATRIX_HELP)
+        raise SystemExit(2) from exc
 
 def _resolve_profiles(
     *,
@@ -142,7 +154,6 @@ def _resolve_profiles(
     stage: Optional[int],
     limit: Optional[int],
     cli_output: ServeOutputConfig | None,
-    cli_payload: Optional[str],
     workspace,
     cli_log_level: Optional[str],
     base_log_level: str,
@@ -157,7 +168,6 @@ def _resolve_profiles(
         stage=stage,
         limit=limit,
         cli_output=cli_output,
-        cli_payload=cli_payload,
         workspace=workspace,
         cli_log_level=cli_log_level,
         base_log_level=base_log_level,
@@ -215,8 +225,9 @@ def handle_serve(
     stage: Optional[int] = None,
     output_transport: Optional[str] = None,
     output_format: Optional[str] = None,
-    output_payload: Optional[str] = None,
     output_directory: Optional[str] = None,
+    output_encoding: Optional[str] = None,
+    output_view: Optional[str] = None,
     skip_build: bool = False,
     *,
     cli_log_level: Optional[str],
@@ -228,9 +239,14 @@ def handle_serve(
     project_path = Path(project)
     run_entries, run_root = resolve_run_entries(project_path, run_name)
 
-    cli_output_cfg, payload_override = _build_cli_output_config(
-        output_transport, output_format, output_directory, output_payload, workspace)
-    cli_payload = payload_override
+    cli_output_cfg = _build_cli_output_config(
+        output_transport,
+        output_format,
+        output_directory,
+        output_encoding,
+        workspace=workspace,
+        view=output_view,
+    )
     try:
         profiles = _resolve_profiles(
             project_path=project_path,
@@ -239,7 +255,6 @@ def handle_serve(
             stage=stage,
             limit=limit,
             cli_output=cli_output_cfg,
-            cli_payload=cli_payload,
             workspace=workspace,
             cli_log_level=cli_log_level,
             base_log_level=base_log_level,
@@ -272,7 +287,6 @@ def handle_serve(
             stage=stage,
             limit=limit,
             cli_output=cli_output_cfg,
-            cli_payload=cli_payload,
             workspace=workspace,
             cli_log_level=cli_log_level,
             base_log_level=base_log_level,

--- a/src/datapipeline/config/context.py
+++ b/src/datapipeline/config/context.py
@@ -130,7 +130,6 @@ def resolve_run_profiles(
     stage: Optional[int],
     limit: Optional[int],
     cli_output,
-    cli_payload: Optional[str],
     workspace: WorkspaceContext | None,
     cli_log_level: Optional[str],
     base_log_level: str,
@@ -190,7 +189,6 @@ def resolve_run_profiles(
             default=runtime_output_cfg,
             base_path=project_path.parent,
             run_name=entry_name or f"run{idx}",
-            payload_override=cli_payload,
             stage=resolved_stage,
             create_run=create_run,
         )

--- a/src/datapipeline/config/options.py
+++ b/src/datapipeline/config/options.py
@@ -5,8 +5,9 @@ stay in sync.
 """
 
 OUTPUT_TRANSPORTS = ("stdout", "fs")
-OUTPUT_FORMATS = ("print", "jsonl", "json", "csv", "pickle")
-OUTPUT_STDOUT_FORMATS = ("print", "jsonl", "json")
+OUTPUT_FORMATS = ("print", "jsonl", "csv", "pickle")
+OUTPUT_STDOUT_FORMATS = ("print", "jsonl")
+OUTPUT_VIEWS = ("flat", "raw", "numeric")
 
 SOURCE_TRANSPORTS = ("fs", "http", "synthetic")
 SOURCE_FS_HTTP_FORMATS = ("csv", "json", "jsonl")

--- a/src/datapipeline/config/options.py
+++ b/src/datapipeline/config/options.py
@@ -7,7 +7,7 @@ stay in sync.
 OUTPUT_TRANSPORTS = ("stdout", "fs")
 OUTPUT_FORMATS = ("print", "jsonl", "csv", "pickle")
 OUTPUT_STDOUT_FORMATS = ("print", "jsonl")
-OUTPUT_VIEWS = ("flat", "raw", "numeric")
+OUTPUT_VIEWS = ("flat", "raw", "values")
 
 SOURCE_TRANSPORTS = ("fs", "http", "synthetic")
 SOURCE_FS_HTTP_FORMATS = ("csv", "json", "jsonl")

--- a/src/datapipeline/config/resolution.py
+++ b/src/datapipeline/config/resolution.py
@@ -130,6 +130,7 @@ def workspace_output_defaults(
     return ServeOutputConfig(
         transport=od.transport,
         format=od.format,
-        payload=od.payload,
+        view=od.view,
+        encoding=od.encoding,
         directory=output_dir,
     )

--- a/src/datapipeline/config/tasks.py
+++ b/src/datapipeline/config/tasks.py
@@ -15,7 +15,7 @@ VALID_PROGRESS_STYLES = ("AUTO", "SPINNER", "BARS", "OFF")
 
 Transport = Literal["fs", "stdout"]
 Format = Literal["csv", "jsonl", "print", "pickle"]
-View = Literal["flat", "raw", "numeric"]
+View = Literal["flat", "raw", "values"]
 
 
 class TaskBase(BaseModel):
@@ -83,7 +83,7 @@ class ServeOutputConfig(BaseModel):
                            description="csv | jsonl | print | pickle")
     view: View | None = Field(
         default=None,
-        description="flat | raw | numeric (unset uses format default)",
+        description="flat | raw | values (unset uses format default)",
     )
     directory: Path | None = Field(
         default=None,
@@ -151,8 +151,8 @@ class ServeOutputConfig(BaseModel):
             raise ValueError("fs transport cannot use 'print' format")
         elif self.directory is None:
             raise ValueError("fs outputs require a directory")
-        if self.format == "csv" and self.view not in {None, "flat", "numeric"}:
-            raise ValueError("csv output supports only view='flat' or view='numeric'")
+        if self.format == "csv" and self.view not in {None, "flat", "values"}:
+            raise ValueError("csv output supports only view='flat' or view='values'")
         if self.transport == "fs":
             if self.format == "pickle":
                 if self.encoding is not None:

--- a/src/datapipeline/config/workspace.py
+++ b/src/datapipeline/config/workspace.py
@@ -73,7 +73,7 @@ class ServeDefaults(BaseModel):
         format: str
         view: Optional[str] = Field(
             default=None,
-            description="flat | raw | numeric",
+            description="flat | raw | values",
         )
         encoding: Optional[str] = Field(
             default=None,

--- a/src/datapipeline/config/workspace.py
+++ b/src/datapipeline/config/workspace.py
@@ -71,7 +71,14 @@ class ServeDefaults(BaseModel):
     class OutputDefaults(BaseModel):
         transport: str
         format: str
-        payload: str = Field(default="sample")
+        view: Optional[str] = Field(
+            default=None,
+            description="flat | raw | numeric",
+        )
+        encoding: Optional[str] = Field(
+            default=None,
+            description="Text encoding for fs jsonl/csv outputs.",
+        )
         directory: Optional[str] = Field(
             default=None,
             description="Base directory for fs outputs (relative paths are resolved from jerry.yaml).",

--- a/src/datapipeline/io/csv_projection.py
+++ b/src/datapipeline/io/csv_projection.py
@@ -1,0 +1,38 @@
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+
+class CsvRowProjector(Protocol):
+    def __call__(self, item: Any) -> dict[str, Any]:
+        ...
+
+
+@dataclass(frozen=True)
+class CsvProjectedRow:
+    header: list[str]
+    values: list[Any]
+
+
+class CsvTableProjector:
+    """Projects rows into a stable table schema (header locked on first row)."""
+
+    def __init__(self, row_projector: CsvRowProjector) -> None:
+        self._row_projector = row_projector
+        self._header: list[str] | None = None
+
+    def project(self, item: Any) -> CsvProjectedRow:
+        row = self._row_projector(item)
+        if self._header is None:
+            self._header = list(row.keys())
+        else:
+            unexpected = [name for name in row.keys() if name not in self._header]
+            if unexpected:
+                raise ValueError(
+                    "CSV row contains fields not present in header: "
+                    + ", ".join(unexpected)
+                )
+        assert self._header is not None
+        return CsvProjectedRow(
+            header=self._header,
+            values=[row.get(field, "") for field in self._header],
+        )

--- a/src/datapipeline/io/normalization.py
+++ b/src/datapipeline/io/normalization.py
@@ -1,0 +1,140 @@
+import json
+from dataclasses import asdict, dataclass, is_dataclass
+from datetime import date, datetime
+from typing import Any, Literal
+
+from datapipeline.domain.sample import Sample
+
+ItemType = Literal["sample", "record"]
+View = Literal["flat", "raw", "numeric"]
+
+
+@dataclass(frozen=True)
+class NormalizedRow:
+    key: Any
+    kind: str
+    fields: dict[str, Any]
+    raw: Any
+
+
+def normalize_item(item: Any, item_type: ItemType) -> NormalizedRow:
+    if item_type == "sample":
+        return _normalize_sample(item)
+    if item_type == "record":
+        return _normalize_record(item)
+    raise ValueError(f"Unsupported item_type '{item_type}'")
+
+
+def normalized_payload(row: NormalizedRow, view: View = "flat") -> dict[str, Any]:
+    key = _normalize_key_struct(row.key)
+    base = {"key": key, "kind": row.kind}
+    if view == "flat":
+        return {**base, "fields": row.fields}
+    if view == "raw":
+        return {**base, "raw": row.raw}
+    if view == "numeric":
+        return {**base, "values": _numeric_values(row.fields)}
+    raise ValueError(f"Unsupported view '{view}'")
+
+
+def _numeric_values(fields: dict[str, Any]) -> list[float]:
+    values: list[float] = []
+    for key in sorted(fields):
+        values.append(_coerce_numeric(key, fields[key]))
+    return values
+
+
+def _coerce_numeric(key: str, value: Any) -> float:
+    if isinstance(value, bool):
+        return float(int(value))
+    if isinstance(value, (int, float)):
+        return float(value)
+    raise ValueError(
+        f"Field '{key}' is non-numeric in numeric view (got {type(value).__name__})"
+    )
+
+
+def _normalize_sample(sample: Sample) -> NormalizedRow:
+    raw = sample.as_full_payload()
+    fields: dict[str, Any] = {}
+    _flatten_fields("features", sample.features.values, fields)
+    if sample.targets is not None:
+        _flatten_fields("targets", sample.targets.values, fields)
+    return NormalizedRow(
+        key=sample.key,
+        kind=type(sample).__name__,
+        fields=fields,
+        raw=raw,
+    )
+
+
+def _normalize_record(item: Any) -> NormalizedRow:
+    raw = _jsonable(item)
+    fields: dict[str, Any] = {}
+    if isinstance(raw, dict):
+        for key, value in sorted(raw.items(), key=lambda kv: str(kv[0])):
+            _flatten_fields(str(key), value, fields)
+    else:
+        _flatten_fields("value", raw, fields)
+    return NormalizedRow(
+        key=_record_key(item),
+        kind=type(item).__name__,
+        fields=fields,
+        raw=raw,
+    )
+
+
+def _normalize_key_struct(key: Any) -> Any:
+    if isinstance(key, tuple):
+        return list(key)
+    return key
+
+
+def _record_key(value: Any) -> Any:
+    direct = getattr(value, "time", None)
+    if direct is not None:
+        return direct
+    record = getattr(value, "record", None)
+    if record is not None:
+        return getattr(record, "time", None)
+    return None
+
+
+def _jsonable(value: Any) -> Any:
+    if value is None:
+        return None
+    if is_dataclass(value):
+        attrs = getattr(value, "__dict__", None)
+        if attrs is not None:
+            return {k: _jsonable(v) for k, v in attrs.items() if not k.startswith("_")}
+        return asdict(value)
+    if isinstance(value, dict):
+        return {k: _jsonable(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_jsonable(v) for v in value]
+    attrs = getattr(value, "__dict__", None)
+    if attrs:
+        return {k: _jsonable(v) for k, v in attrs.items() if not k.startswith("_")}
+    return value
+
+
+def _is_scalar(value: Any) -> bool:
+    return value is None or isinstance(value, (str, int, float, bool, datetime, date))
+
+
+def _flatten_fields(prefix: str, value: Any, out: dict[str, Any]) -> None:
+    if _is_scalar(value):
+        out[prefix] = value
+        return
+    if isinstance(value, dict):
+        for key, nested in sorted(value.items(), key=lambda kv: str(kv[0])):
+            _flatten_fields(f"{prefix}.{key}", nested, out)
+        return
+    if isinstance(value, (list, tuple)):
+        if all(_is_scalar(item) for item in value):
+            for idx, nested in enumerate(value):
+                out[f"{prefix}.{idx}"] = nested
+            return
+        out[prefix] = json.dumps(value, ensure_ascii=False, default=str)
+        return
+    out[prefix] = str(value)

--- a/src/datapipeline/io/output.py
+++ b/src/datapipeline/io/output.py
@@ -10,11 +10,20 @@ from datapipeline.services.runs import RunPaths, start_run_for_directory
 def _format_suffix(fmt: str) -> str:
     suffix_map = {
         "jsonl": ".jsonl",
-        "json": ".json",
         "csv": ".csv",
         "pickle": ".pkl",
     }
     return suffix_map.get(fmt, ".out")
+
+
+def _default_view_for_format(fmt: str) -> str:
+    if fmt in {"print", "jsonl"}:
+        return "raw"
+    return "flat"
+
+
+def _resolve_view(fmt: str, configured_view: str | None) -> str:
+    return configured_view or _default_view_for_format(fmt)
 
 
 def _default_filename_for_format(fmt: str) -> str:
@@ -35,9 +44,10 @@ class OutputTarget:
     """Resolved writer target describing how and where to emit records."""
 
     transport: str  # stdout | fs
-    format: str     # print | jsonl | json | csv | pickle
+    format: str     # print | jsonl | csv | pickle
+    view: str       # flat | raw | numeric
+    encoding: str | None
     destination: Optional[Path]
-    payload: str = "sample"
     run: RunPaths | None = None
 
     def for_feature(self, feature_id: str) -> "OutputTarget":
@@ -55,8 +65,9 @@ class OutputTarget:
         return OutputTarget(
             transport=self.transport,
             format=self.format,
+            view=self.view,
+            encoding=self.encoding,
             destination=new_path,
-            payload=self.payload,
             run=self.run,
         )
 
@@ -72,7 +83,6 @@ def resolve_output_target(
     default: ServeOutputConfig | None = None,
     base_path: Path | None = None,
     run_name: str | None = None,
-    payload_override: str | None = None,
     stage: int | None = None,
     create_run: bool = False,
 ) -> OutputTarget:
@@ -86,14 +96,13 @@ def resolve_output_target(
     if config is None:
         config = ServeOutputConfig(transport="stdout", format="print")
 
-    payload = payload_override or config.payload or "sample"
-
     if config.transport == "stdout":
         return OutputTarget(
             transport="stdout",
             format=config.format,
+            view=_resolve_view(config.format, config.view),
+            encoding=None,
             destination=None,
-            payload=payload,
             run=None,
         )
 
@@ -121,7 +130,8 @@ def resolve_output_target(
     return OutputTarget(
         transport="fs",
         format=config.format,
+        view=_resolve_view(config.format, config.view),
+        encoding=config.encoding,
         destination=dest_path,
-        payload=payload,
         run=run_paths,
     )

--- a/src/datapipeline/io/output.py
+++ b/src/datapipeline/io/output.py
@@ -45,7 +45,7 @@ class OutputTarget:
 
     transport: str  # stdout | fs
     format: str     # print | jsonl | csv | pickle
-    view: str       # flat | raw | numeric
+    view: str       # flat | raw | values
     encoding: str | None
     destination: Optional[Path]
     run: RunPaths | None = None

--- a/src/datapipeline/io/serializers.py
+++ b/src/datapipeline/io/serializers.py
@@ -33,8 +33,8 @@ class PrintSerializer:
 
 class CsvRowSerializer:
     def __init__(self, item_type: ItemType, view: View) -> None:
-        if view not in {"flat", "numeric"}:
-            raise ValueError("csv output supports only view='flat' or view='numeric'")
+        if view not in {"flat", "values"}:
+            raise ValueError("csv output supports only view='flat' or view='values'")
         self._item_type = item_type
         self._view = view
 
@@ -48,7 +48,7 @@ class CsvRowSerializer:
                 out[f"field.{field}"] = value
             return out
 
-        payload = normalized_payload(row, "numeric")
+        payload = normalized_payload(row, "values")
         for idx, value in enumerate(payload["values"]):
             out[f"value_{idx}"] = value
         return out

--- a/src/datapipeline/io/serializers.py
+++ b/src/datapipeline/io/serializers.py
@@ -1,229 +1,110 @@
 import json
-from dataclasses import asdict, is_dataclass
-from typing import Any, Dict, Type
+from datetime import date, datetime
+from typing import Any, Literal
+
+from datapipeline.io.normalization import View, normalize_item, normalized_payload
 
-from datapipeline.domain.sample import Sample
+ItemType = Literal["sample", "record"]
 
 
-class BaseSerializer:
-    payload_mode = "sample"
-
-    def serialize_payload(self, sample: Sample) -> Any:  # pragma: no cover - abstract
-        raise NotImplementedError
-
-
-class BaseJsonLineSerializer(BaseSerializer):
-    def __call__(self, sample: Sample) -> str:
-        data = self.serialize_payload(sample)
-        return json.dumps(data, ensure_ascii=False, default=str) + "\n"
-
-
-class SampleJsonLineSerializer(BaseJsonLineSerializer):
-    payload_mode = "sample"
-
-    def serialize_payload(self, sample: Sample) -> Any:
-        return sample.as_full_payload()
-
-
-class VectorJsonLineSerializer(BaseJsonLineSerializer):
-    payload_mode = "vector"
-
-    def serialize_payload(self, sample: Sample) -> Any:
-        return sample.as_vector_payload()
-
-
-class BasePrintSerializer(BaseSerializer):
-    def __call__(self, sample: Sample) -> str:
-        value = self.serialize_payload(sample)
-        return f"{value}\n"
-
-
-class SamplePrintSerializer(BasePrintSerializer):
-    payload_mode = "sample"
-
-    def serialize_payload(self, sample: Sample) -> Any:
-        return sample.as_full_payload()
-
-
-class VectorPrintSerializer(BasePrintSerializer):
-    payload_mode = "vector"
-
-    def serialize_payload(self, sample: Sample) -> Any:
-        return sample.as_vector_payload()
-
-
-class BaseCsvRowSerializer(BaseSerializer):
-    def __call__(self, sample: Sample) -> list[str | Any]:
-        key_value = sample.key
-        if isinstance(key_value, tuple):
-            key_struct = list(key_value)
-        else:
-            key_struct = key_value
-        if isinstance(key_struct, (list, dict)):
-            key_text = json.dumps(key_struct, ensure_ascii=False, default=str)
-        else:
-            key_text = "" if key_struct is None else str(key_struct)
-
-        payload_data = self.serialize_payload(sample)
-        if isinstance(payload_data, dict):
-            payload_data.pop("key", None)
-        payload_text = json.dumps(payload_data, ensure_ascii=False, default=str)
-        return [key_text, payload_text]
-
-
-class SampleCsvRowSerializer(BaseCsvRowSerializer):
-    payload_mode = "sample"
-
-    def serialize_payload(self, sample: Sample) -> Any:
-        return sample.as_full_payload()
-
-
-class VectorCsvRowSerializer(BaseCsvRowSerializer):
-    payload_mode = "vector"
-
-    def serialize_payload(self, sample: Sample) -> Any:
-        return sample.as_vector_payload()
-
-
-class BasePickleSerializer(BaseSerializer):
-    def __call__(self, sample: Sample) -> Any:
-        return self.serialize_payload(sample)
-
-
-class SamplePickleSerializer(BasePickleSerializer):
-    payload_mode = "sample"
-
-    def serialize_payload(self, sample: Sample) -> Any:
-        return sample
-
-
-class VectorPickleSerializer(BasePickleSerializer):
-    payload_mode = "vector"
-
-    def serialize_payload(self, sample: Sample) -> Any:
-        return sample.as_vector_payload()
-
-
-def _record_payload(value: Any) -> Any:
-    def _convert(obj: Any) -> Any:
-        if obj is None:
-            return None
-        if is_dataclass(obj):
-            attrs = getattr(obj, "__dict__", None)
-            if attrs is not None:
-                return {
-                    k: _convert(v)
-                    for k, v in attrs.items()
-                    if not k.startswith("_")
-                }
-            return asdict(obj)
-        if isinstance(obj, dict):
-            return {k: _convert(v) for k, v in obj.items()}
-        if isinstance(obj, (list, tuple)):
-            return [_convert(v) for v in obj]
-        attrs = getattr(obj, "__dict__", None)
-        if attrs:
-            return {
-                k: _convert(v)
-                for k, v in attrs.items()
-                if not k.startswith("_")
-            }
-        return obj
-
-    return _convert(value)
-
-
-def _record_key(value: Any) -> Any:
-    direct = getattr(value, "time", None)
-    if direct is not None:
-        return direct
-    record = getattr(value, "record", None)
-    if record is not None:
-        return getattr(record, "time", None)
-    return None
-
-
-class RecordJsonLineSerializer:
-    def __call__(self, record: Any) -> str:
-        payload = _record_payload(record)
-        return json.dumps(payload, ensure_ascii=False, default=str) + "\n"
-
-
-class RecordPrintSerializer:
-    def __call__(self, record: Any) -> str:
-        return f"{_record_payload(record)}\n"
-
-
-class RecordCsvRowSerializer:
-    def __call__(self, record: Any) -> list[str | Any]:
-        key_value = _record_key(record)
-        key_text = "" if key_value is None else str(key_value)
-        payload = json.dumps(_record_payload(record), ensure_ascii=False, default=str)
-        return [key_text, payload]
-
-
-class RecordPickleSerializer:
-    def __call__(self, record: Any) -> Any:
-        return record
-
-
-def _serializer_factory(
-    registry: Dict[str, Type[BaseSerializer]],
-    payload: str,
-    default_cls: Type[BaseSerializer],
-) -> BaseSerializer:
-    cls = registry.get(payload, default_cls)
-    return cls()
-
-
-JSON_SERIALIZERS: Dict[str, Type[BaseJsonLineSerializer]] = {
-    SampleJsonLineSerializer.payload_mode: SampleJsonLineSerializer,
-    VectorJsonLineSerializer.payload_mode: VectorJsonLineSerializer,
-}
-
-PRINT_SERIALIZERS: Dict[str, Type[BasePrintSerializer]] = {
-    SamplePrintSerializer.payload_mode: SamplePrintSerializer,
-    VectorPrintSerializer.payload_mode: VectorPrintSerializer,
-}
-
-CSV_SERIALIZERS: Dict[str, Type[BaseCsvRowSerializer]] = {
-    SampleCsvRowSerializer.payload_mode: SampleCsvRowSerializer,
-    VectorCsvRowSerializer.payload_mode: VectorCsvRowSerializer,
-}
-
-PICKLE_SERIALIZERS: Dict[str, Type[BasePickleSerializer]] = {
-    SamplePickleSerializer.payload_mode: SamplePickleSerializer,
-    VectorPickleSerializer.payload_mode: VectorPickleSerializer,
-}
-
-
-def json_line_serializer(payload: str) -> BaseJsonLineSerializer:
-    return _serializer_factory(JSON_SERIALIZERS, payload, SampleJsonLineSerializer)
-
-
-def print_serializer(payload: str) -> BasePrintSerializer:
-    return _serializer_factory(PRINT_SERIALIZERS, payload, SamplePrintSerializer)
-
-
-def csv_row_serializer(payload: str) -> BaseCsvRowSerializer:
-    return _serializer_factory(CSV_SERIALIZERS, payload, SampleCsvRowSerializer)
-
-
-def pickle_serializer(payload: str) -> BasePickleSerializer:
-    return _serializer_factory(PICKLE_SERIALIZERS, payload, SamplePickleSerializer)
-
-
-def record_json_line_serializer() -> RecordJsonLineSerializer:
-    return RecordJsonLineSerializer()
-
-
-def record_print_serializer() -> RecordPrintSerializer:
-    return RecordPrintSerializer()
-
-
-def record_csv_row_serializer() -> RecordCsvRowSerializer:
-    return RecordCsvRowSerializer()
-
-
-def record_pickle_serializer() -> RecordPickleSerializer:
-    return RecordPickleSerializer()
+class JsonLineSerializer:
+    def __init__(self, item_type: ItemType, view: View) -> None:
+        self._item_type = item_type
+        self._view = view
+
+    def __call__(self, item: Any) -> str:
+        row = normalize_item(item, self._item_type)
+        return json.dumps(
+            normalized_payload(row, self._view),
+            ensure_ascii=False,
+            default=str,
+        ) + "\n"
+
+
+class PrintSerializer:
+    def __init__(self, item_type: ItemType, view: View) -> None:
+        self._item_type = item_type
+        self._view = view
+
+    def __call__(self, item: Any) -> str:
+        row = normalize_item(item, self._item_type)
+        return f"{normalized_payload(row, self._view)}\n"
+
+
+class CsvRowSerializer:
+    def __init__(self, item_type: ItemType, view: View) -> None:
+        if view not in {"flat", "numeric"}:
+            raise ValueError("csv output supports only view='flat' or view='numeric'")
+        self._item_type = item_type
+        self._view = view
+
+    def __call__(self, item: Any) -> dict[str, Any]:
+        row = normalize_item(item, self._item_type)
+        out: dict[str, Any] = {}
+        _add_key_columns(row.key, out)
+        out["kind"] = row.kind
+        if self._view == "flat":
+            for field, value in row.fields.items():
+                out[f"field.{field}"] = value
+            return out
+
+        payload = normalized_payload(row, "numeric")
+        for idx, value in enumerate(payload["values"]):
+            out[f"value_{idx}"] = value
+        return out
+
+
+class PickleSerializer:
+    def __init__(self, item_type: ItemType, view: View) -> None:
+        self._item_type = item_type
+        self._view = view
+
+    def __call__(self, item: Any) -> Any:
+        row = normalize_item(item, self._item_type)
+        return normalized_payload(row, self._view)
+
+
+def json_line_serializer(
+    item_type: ItemType = "sample",
+    view: View = "flat",
+) -> JsonLineSerializer:
+    return JsonLineSerializer(item_type, view)
+
+
+def print_serializer(
+    item_type: ItemType = "sample",
+    view: View = "flat",
+) -> PrintSerializer:
+    return PrintSerializer(item_type, view)
+
+
+def csv_row_serializer(
+    item_type: ItemType = "sample",
+    view: View = "flat",
+) -> CsvRowSerializer:
+    return CsvRowSerializer(item_type, view)
+
+
+def pickle_serializer(
+    item_type: ItemType = "sample",
+    view: View = "flat",
+) -> PickleSerializer:
+    return PickleSerializer(item_type, view)
+
+
+def _add_key_columns(key: Any, row: dict[str, Any]) -> None:
+    if isinstance(key, tuple):
+        for idx, value in enumerate(key):
+            row[f"key_{idx}"] = _csv_cell_value(value)
+        return
+    if isinstance(key, list):
+        for idx, value in enumerate(key):
+            row[f"key_{idx}"] = _csv_cell_value(value)
+        return
+    row["key"] = _csv_cell_value(key)
+
+
+def _csv_cell_value(value: Any) -> Any:
+    if isinstance(value, (datetime, date)):
+        return str(value)
+    return value

--- a/src/datapipeline/io/sinks/files.py
+++ b/src/datapipeline/io/sinks/files.py
@@ -7,13 +7,13 @@ from .base import BaseSink
 
 
 class AtomicTextFileSink(BaseSink):
-    def __init__(self, dest: Path):
+    def __init__(self, dest: Path, encoding: str = "utf-8"):
         self._dest = dest
         dest.parent.mkdir(parents=True, exist_ok=True)
         self._tmp = Path(
             tempfile.NamedTemporaryFile(dir=str(dest.parent), delete=False).name
         )
-        self._fh = open(self._tmp, "w", encoding="utf-8")
+        self._fh = open(self._tmp, "w", encoding=encoding)
 
     @property
     def file_path(self) -> Path:

--- a/src/datapipeline/io/writers/csv_writer.py
+++ b/src/datapipeline/io/writers/csv_writer.py
@@ -2,24 +2,30 @@ import csv
 from pathlib import Path
 from typing import Optional
 
-from datapipeline.io.serializers import csv_row_serializer, BaseCsvRowSerializer
+from datapipeline.io.csv_projection import CsvTableProjector
+from datapipeline.io.serializers import csv_row_serializer
 from datapipeline.io.protocols import HasFilePath, Writer
 from datapipeline.io.sinks import AtomicTextFileSink
 
 
 class CsvFileWriter(Writer, HasFilePath):
-    def __init__(self, dest: Path, serializer: BaseCsvRowSerializer | None = None):
-        self.sink = AtomicTextFileSink(dest)
+    def __init__(self, dest: Path, serializer=None, encoding: str = "utf-8"):
+        self.sink = AtomicTextFileSink(dest, encoding=encoding)
         self.writer = csv.writer(self.sink.fh)
-        self.writer.writerow(["key", "values"])
-        self._serializer = serializer or csv_row_serializer("sample")
+        self._header_written = False
+        row_projector = serializer or csv_row_serializer()
+        self._projector = CsvTableProjector(row_projector)
 
     @property
     def file_path(self) -> Optional[Path]:
         return self.sink.file_path
 
     def write(self, item) -> None:
-        self.writer.writerow(self._serializer(item))
+        projected = self._projector.project(item)
+        if not self._header_written:
+            self.writer.writerow(projected.header)
+            self._header_written = True
+        self.writer.writerow(projected.values)
 
     def close(self) -> None:
         self.sink.close()

--- a/src/datapipeline/io/writers/jsonl.py
+++ b/src/datapipeline/io/writers/jsonl.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from typing import Optional
 import json
 
-from datapipeline.io.serializers import json_line_serializer, BaseJsonLineSerializer
+from datapipeline.io.serializers import json_line_serializer
 from datapipeline.io.protocols import HeaderCapable, HasFilePath, Writer
 from datapipeline.io.sinks import (
     AtomicTextFileSink,
@@ -14,14 +14,14 @@ from .base import HeaderJsonlMixin, LineWriter
 
 
 class JsonLinesStdoutWriter(LineWriter, HeaderJsonlMixin):
-    def __init__(self, serializer: BaseJsonLineSerializer | None = None):
-        super().__init__(StdoutTextSink(), serializer or json_line_serializer("sample"))
+    def __init__(self, serializer=None):
+        super().__init__(StdoutTextSink(), serializer or json_line_serializer())
 
 
 class JsonLinesFileWriter(LineWriter, HeaderJsonlMixin, HasFilePath):
-    def __init__(self, dest: Path, serializer: BaseJsonLineSerializer | None = None):
-        self._sink = AtomicTextFileSink(dest)
-        super().__init__(self._sink, serializer or json_line_serializer("sample"))
+    def __init__(self, dest: Path, serializer=None, encoding: str = "utf-8"):
+        self._sink = AtomicTextFileSink(dest, encoding=encoding)
+        super().__init__(self._sink, serializer or json_line_serializer())
 
     @property
     def file_path(self) -> Optional[Path]:
@@ -29,9 +29,10 @@ class JsonLinesFileWriter(LineWriter, HeaderJsonlMixin, HasFilePath):
 
 
 class GzipJsonLinesWriter(Writer, HeaderCapable, HasFilePath):
-    def __init__(self, dest: Path, serializer: BaseJsonLineSerializer | None = None):
+    def __init__(self, dest: Path, serializer=None, encoding: str = "utf-8"):
         self.sink = GzipBinarySink(dest)
-        self._serializer = serializer or json_line_serializer("sample")
+        self._serializer = serializer or json_line_serializer()
+        self._encoding = encoding
 
     @property
     def file_path(self) -> Optional[Path]:
@@ -40,13 +41,13 @@ class GzipJsonLinesWriter(Writer, HeaderCapable, HasFilePath):
     def write_header(self, header: dict) -> None:
         self.sink.write_bytes(
             (json.dumps({"__checkpoint__": header}, ensure_ascii=False) + "\n").encode(
-                "utf-8"
+                self._encoding
             )
         )
 
     def write(self, item) -> None:
         line = self._serializer(item)
-        self.sink.write_bytes(line.encode("utf-8"))
+        self.sink.write_bytes(line.encode(self._encoding))
 
     def close(self) -> None:
         self.sink.close()

--- a/src/datapipeline/io/writers/pickle_writer.py
+++ b/src/datapipeline/io/writers/pickle_writer.py
@@ -2,7 +2,7 @@ import pickle
 from pathlib import Path
 from typing import Optional
 
-from datapipeline.io.serializers import pickle_serializer, BasePickleSerializer
+from datapipeline.io.serializers import pickle_serializer
 from datapipeline.io.protocols import HasFilePath, Writer
 from datapipeline.io.sinks import AtomicBinaryFileSink
 
@@ -11,12 +11,12 @@ class PickleFileWriter(Writer, HasFilePath):
     def __init__(
         self,
         dest: Path,
-        serializer: BasePickleSerializer | None = None,
+        serializer=None,
         protocol: int = pickle.HIGHEST_PROTOCOL,
     ):
         self.sink = AtomicBinaryFileSink(dest)
         self.pickler = pickle.Pickler(self.sink.fh, protocol=protocol)
-        self._serializer = serializer or pickle_serializer("sample")
+        self._serializer = serializer or pickle_serializer()
 
     @property
     def file_path(self) -> Optional[Path]:

--- a/src/datapipeline/templates/plugin_skeleton/reference/jerry.yaml
+++ b/src/datapipeline/templates/plugin_skeleton/reference/jerry.yaml
@@ -20,7 +20,7 @@
 #   output:                        # optional
 #     transport: stdout            # optional; stdout | fs
 #     format: jsonl                # optional; stdout: print | jsonl
-#     # view: raw                  # optional; flat | raw | numeric
+#     # view: raw                  # optional; flat | raw | values
 #     #                            # default: print/jsonl->raw, csv/pickle->flat
 #     # encoding: utf-8            # optional; fs jsonl/csv only
 #     # directory: artifacts/serve # optional; fs only; relative to jerry.yaml

--- a/src/datapipeline/templates/plugin_skeleton/reference/jerry.yaml
+++ b/src/datapipeline/templates/plugin_skeleton/reference/jerry.yaml
@@ -19,8 +19,10 @@
 #   throttle_ms: 0                 # optional
 #   output:                        # optional
 #     transport: stdout            # optional; stdout | fs
-#     format: jsonl           # optional; stdout: print | jsonl | json
-#     payload: sample              # optional; sample | vector
+#     format: jsonl                # optional; stdout: print | jsonl
+#     # view: raw                  # optional; flat | raw | numeric
+#     #                            # default: print/jsonl->raw, csv/pickle->flat
+#     # encoding: utf-8            # optional; fs jsonl/csv only
 #     # directory: artifacts/serve # optional; fs only; relative to jerry.yaml
 #
 # build:                           # optional

--- a/src/datapipeline/templates/plugin_skeleton/reference/reference/tasks/serve.reference.yaml
+++ b/src/datapipeline/templates/plugin_skeleton/reference/reference/tasks/serve.reference.yaml
@@ -10,12 +10,13 @@
 #
 # output:                     # optional; omit to use CLI defaults
 #   transport: stdout          # stdout | fs
-#   format: jsonl         # stdout: print | jsonl | json
-#   payload: sample            # sample | vector
+#   format: jsonl              # stdout: print | jsonl
+#   # view: raw               # optional; flat | raw | numeric
+#   #                         # default: print/jsonl->raw, csv/pickle->flat
+#   # encoding: utf-8          # fs jsonl/csv only
 #   # fs transport only:
 #   # transport: fs
-#   # format: csv        # csv | json | jsonl | pickle
-#   # payload: vector
+#   # format: csv             # csv | jsonl | pickle
 #   # directory: artifacts/serve
 #   # filename: vectors.train  # no extension, no path separators
 #

--- a/src/datapipeline/templates/plugin_skeleton/reference/reference/tasks/serve.reference.yaml
+++ b/src/datapipeline/templates/plugin_skeleton/reference/reference/tasks/serve.reference.yaml
@@ -11,7 +11,7 @@
 # output:                     # optional; omit to use CLI defaults
 #   transport: stdout          # stdout | fs
 #   format: jsonl              # stdout: print | jsonl
-#   # view: raw               # optional; flat | raw | numeric
+#   # view: raw               # optional; flat | raw | values
 #   #                         # default: print/jsonl->raw, csv/pickle->flat
 #   # encoding: utf-8          # fs jsonl/csv only
 #   # fs transport only:

--- a/tests/unit/cli/test_run_cli.py
+++ b/tests/unit/cli/test_run_cli.py
@@ -54,7 +54,6 @@ def test_run_profiles_inherit_workspace_throttle(monkeypatch, tmp_path):
         stage=None,
         limit=None,
         cli_output=None,
-        cli_payload=None,
         workspace=workspace,
         cli_log_level=None,
         base_log_level="INFO",
@@ -69,14 +68,12 @@ def test_cli_output_directory_resolves_relative_to_workspace(tmp_path):
     workspace_cfg = WorkspaceConfig.model_validate({})
     workspace = WorkspaceContext(file_path=tmp_path / "jerry.yaml", config=workspace_cfg)
 
-    cfg, payload = _build_cli_output_config(
+    cfg = _build_cli_output_config(
         "fs",
-        "json",
+        "jsonl",
         ".",
-        None,
-        workspace,
+        workspace=workspace,
     )
 
-    assert payload is None
     assert cfg is not None
     assert cfg.directory == tmp_path.resolve()

--- a/tests/unit/cli/test_run_command.py
+++ b/tests/unit/cli/test_run_command.py
@@ -54,10 +54,10 @@ def test_build_cli_output_config_honors_view() -> None:
         transport="stdout",
         fmt="jsonl",
         directory=None,
-        view="numeric",
+        view="values",
     )
     assert config is not None
-    assert config.view == "numeric"
+    assert config.view == "values"
 
 
 def test_build_cli_output_config_rejects_non_flat_csv_view() -> None:

--- a/tests/unit/cli/test_serve_preview_plan.py
+++ b/tests/unit/cli/test_serve_preview_plan.py
@@ -1,0 +1,36 @@
+from types import SimpleNamespace
+
+from datapipeline.cli.commands.serve_pipeline import _preview_plan
+
+
+def _cfg(id_: str, record_stream: str):
+    return SimpleNamespace(id=id_, record_stream=record_stream)
+
+
+def test_preview_plan_dedupes_shared_streams_for_early_stages() -> None:
+    preview_cfgs = [
+        _cfg("closing_price", "equity.ohlcv"),
+        _cfg("opening_price", "equity.ohlcv"),
+        _cfg("linear_time", "time.ticks.linear"),
+    ]
+
+    plan = _preview_plan(preview_cfgs, stage=0)
+
+    assert plan == [
+        ("equity.ohlcv", preview_cfgs[0]),
+        ("time.ticks.linear", preview_cfgs[2]),
+    ]
+
+
+def test_preview_plan_keeps_feature_scope_for_feature_stages() -> None:
+    preview_cfgs = [
+        _cfg("closing_price", "equity.ohlcv"),
+        _cfg("opening_price", "equity.ohlcv"),
+    ]
+
+    plan = _preview_plan(preview_cfgs, stage=5)
+
+    assert plan == [
+        ("closing_price", preview_cfgs[0]),
+        ("opening_price", preview_cfgs[1]),
+    ]

--- a/tests/unit/io/test_csv_writer.py
+++ b/tests/unit/io/test_csv_writer.py
@@ -1,0 +1,68 @@
+import csv
+
+import pytest
+
+from datapipeline.io.writers.csv_writer import CsvFileWriter
+
+
+def test_csv_writer_uses_projected_header(tmp_path) -> None:
+    rows = iter(
+        [
+            {"key": "k1", "feature.temp": 1.0, "feature.wind.0": 2.0},
+            {"key": "k2", "feature.temp": 3.0, "feature.wind.0": 4.0},
+        ]
+    )
+
+    class _Serializer:
+        def __call__(self, _item):
+            return next(rows)
+
+    dest = tmp_path / "out.csv"
+    writer = CsvFileWriter(dest, serializer=_Serializer())
+    writer.write(object())
+    writer.write(object())
+    writer.close()
+
+    with open(dest, newline="", encoding="utf-8") as fh:
+        parsed = list(csv.DictReader(fh))
+
+    assert parsed[0]["key"] == "k1"
+    assert parsed[0]["feature.temp"] == "1.0"
+    assert parsed[1]["key"] == "k2"
+
+
+def test_csv_writer_raises_on_new_columns_after_header(tmp_path) -> None:
+    rows = iter(
+        [
+            {"key": "k1", "feature.temp": 1.0},
+            {"key": "k2", "feature.temp": 2.0, "feature.new": 9.0},
+        ]
+    )
+
+    class _Serializer:
+        def __call__(self, _item):
+            return next(rows)
+
+    dest = tmp_path / "out.csv"
+    writer = CsvFileWriter(dest, serializer=_Serializer())
+    writer.write(object())
+
+    with pytest.raises(ValueError, match="CSV row contains fields not present in header"):
+        writer.write(object())
+    writer.close()
+
+
+def test_csv_writer_honors_configured_encoding(tmp_path) -> None:
+    rows = iter([{"key": "k1", "feature.temp": 1.0}])
+
+    class _Serializer:
+        def __call__(self, _item):
+            return next(rows)
+
+    dest = tmp_path / "out.csv"
+    writer = CsvFileWriter(dest, serializer=_Serializer(), encoding="utf-8-sig")
+    writer.write(object())
+    writer.close()
+
+    raw = dest.read_bytes()
+    assert raw.startswith(b"\xef\xbb\xbf")

--- a/tests/unit/io/test_io_serializers.py
+++ b/tests/unit/io/test_io_serializers.py
@@ -1,35 +1,119 @@
 import json
 from datetime import datetime, timezone
 
+import pytest
+
 from datapipeline.domain.feature import FeatureRecord
 from datapipeline.domain.record import TemporalRecord
+from datapipeline.domain.sample import Sample
+from datapipeline.domain.vector import Vector
 from datapipeline.io.serializers import (
-    record_json_line_serializer,
-    record_csv_row_serializer,
+    csv_row_serializer,
+    json_line_serializer,
 )
 
 
 def test_record_json_serializer_handles_temporal_record() -> None:
     rec = TemporalRecord(time=datetime(2024, 1, 1, tzinfo=timezone.utc))
     setattr(rec, "value", 42.5)
-    serializer = record_json_line_serializer()
+    serializer = json_line_serializer("record")
 
     line = serializer(rec)
     payload = json.loads(line)
 
-    assert payload["time"] == "2024-01-01 00:00:00+00:00"
-    assert payload["value"] == 42.5
+    assert payload["kind"] == "TemporalRecord"
+    assert payload["key"] == "2024-01-01 00:00:00+00:00"
+    assert payload["fields"]["value"] == 42.5
 
 
 def test_record_csv_serializer_uses_nested_record_time() -> None:
     record = TemporalRecord(time=datetime(2024, 7, 4, tzinfo=timezone.utc))
     setattr(record, "value", 7.0)
     feature = FeatureRecord(id="feature_a", record=record, value=7.0)
-    serializer = record_csv_row_serializer()
+    serializer = csv_row_serializer("record")
 
-    key_text, payload_text = serializer(feature)
-    payload = json.loads(payload_text)
+    row = serializer(feature)
 
-    assert key_text == "2024-07-04 00:00:00+00:00"
-    assert payload["id"] == "feature_a"
-    assert payload["record"]["value"] == 7.0
+    assert row["key"] == "2024-07-04 00:00:00+00:00"
+    assert row["kind"] == "FeatureRecord"
+    assert row["field.id"] == "feature_a"
+    assert row["field.record.value"] == 7.0
+
+
+def test_vector_csv_serializer_flattens_feature_values() -> None:
+    serializer = csv_row_serializer()
+    sample = Sample(
+        key=(datetime(2024, 1, 1, tzinfo=timezone.utc),),
+        features=Vector(values={"temp": 1.5, "lag2": [1.0, 1.1]}),
+        targets=Vector(values={"y": 2.0}),
+    )
+
+    row = serializer(sample)
+
+    assert row["key_0"] == "2024-01-01 00:00:00+00:00"
+    assert row["kind"] == "Sample"
+    assert row["field.features.temp"] == 1.5
+    assert row["field.features.lag2.0"] == 1.0
+    assert row["field.features.lag2.1"] == 1.1
+    assert row["field.targets.y"] == 2.0
+
+
+def test_sample_csv_serializer_flattens_with_features_prefix() -> None:
+    serializer = csv_row_serializer()
+    sample = Sample(
+        key="2024-01-01T00:00:00+00:00",
+        features=Vector(values={"wind": [5.0, 6.0]}),
+    )
+
+    row = serializer(sample)
+
+    assert row["key"] == "2024-01-01T00:00:00+00:00"
+    assert row["kind"] == "Sample"
+    assert row["field.features.wind.0"] == 5.0
+    assert row["field.features.wind.1"] == 6.0
+
+
+def test_json_serializer_flat_view_excludes_raw() -> None:
+    serializer = json_line_serializer(view="flat")
+    sample = Sample(
+        key="k1",
+        features=Vector(values={"x": 1.0}),
+    )
+
+    payload = json.loads(serializer(sample))
+    assert payload["key"] == "k1"
+    assert payload["kind"] == "Sample"
+    assert payload["fields"]["features.x"] == 1.0
+    assert "raw" not in payload
+
+
+def test_json_serializer_numeric_view_includes_values_only() -> None:
+    serializer = json_line_serializer(view="numeric")
+    sample = Sample(
+        key="k1",
+        features=Vector(values={"x": 1.0}),
+    )
+
+    payload = json.loads(serializer(sample))
+    assert payload["values"] == [1.0]
+    assert "fields" not in payload
+    assert "raw" not in payload
+
+
+def test_csv_serializer_rejects_non_flat_view() -> None:
+    with pytest.raises(ValueError, match="csv output supports only view='flat' or view='numeric'"):
+        csv_row_serializer(view="raw")
+
+
+def test_csv_serializer_numeric_view_emits_value_columns() -> None:
+    serializer = csv_row_serializer(view="numeric")
+    sample = Sample(
+        key="k1",
+        features=Vector(values={"x": 1.0, "y": 2.0}),
+    )
+
+    row = serializer(sample)
+    assert row["key"] == "k1"
+    assert row["kind"] == "Sample"
+    assert row["value_0"] == 1.0
+    assert row["value_1"] == 2.0

--- a/tests/unit/io/test_io_serializers.py
+++ b/tests/unit/io/test_io_serializers.py
@@ -87,26 +87,26 @@ def test_json_serializer_flat_view_excludes_raw() -> None:
     assert "raw" not in payload
 
 
-def test_json_serializer_numeric_view_includes_values_only() -> None:
-    serializer = json_line_serializer(view="numeric")
+def test_json_serializer_values_view_includes_values_only() -> None:
+    serializer = json_line_serializer(view="values")
     sample = Sample(
         key="k1",
-        features=Vector(values={"x": 1.0}),
+        features=Vector(values={"x": 1.0, "label": "sunny"}),
     )
 
     payload = json.loads(serializer(sample))
-    assert payload["values"] == [1.0]
+    assert payload["values"] == ["sunny", 1.0]
     assert "fields" not in payload
     assert "raw" not in payload
 
 
 def test_csv_serializer_rejects_non_flat_view() -> None:
-    with pytest.raises(ValueError, match="csv output supports only view='flat' or view='numeric'"):
+    with pytest.raises(ValueError, match="csv output supports only view='flat' or view='values'"):
         csv_row_serializer(view="raw")
 
 
-def test_csv_serializer_numeric_view_emits_value_columns() -> None:
-    serializer = csv_row_serializer(view="numeric")
+def test_csv_serializer_values_view_emits_value_columns() -> None:
+    serializer = csv_row_serializer(view="values")
     sample = Sample(
         key="k1",
         features=Vector(values={"x": 1.0, "y": 2.0}),

--- a/tests/unit/io/test_output_resolution.py
+++ b/tests/unit/io/test_output_resolution.py
@@ -47,7 +47,7 @@ def test_resolve_output_target_honors_view(tmp_path):
     cfg = ServeOutputConfig(
         transport="fs",
         format="jsonl",
-        view="numeric",
+        view="values",
         directory=out_dir,
     )
 
@@ -59,7 +59,7 @@ def test_resolve_output_target_honors_view(tmp_path):
         run_name="train",
     )
 
-    assert target.view == "numeric"
+    assert target.view == "values"
 
 
 def test_resolve_output_target_honors_encoding(tmp_path):

--- a/tests/unit/io/test_output_resolution.py
+++ b/tests/unit/io/test_output_resolution.py
@@ -1,9 +1,6 @@
 from pathlib import Path
 
 from datapipeline.config.tasks import ServeOutputConfig
-from datapipeline.domain.sample import Sample
-from datapipeline.domain.vector import Vector
-from datapipeline.io.serializers import json_line_serializer
 from datapipeline.io.output import resolve_output_target
 
 
@@ -84,20 +81,6 @@ def test_resolve_output_target_honors_encoding(tmp_path):
     )
 
     assert target.encoding == "utf-8-sig"
-
-
-def test_json_serializer_includes_sample_key_and_vectors():
-    serializer = json_line_serializer()
-    sample = Sample(
-        key=("2024-01-01T00:00:00Z",),
-        features=Vector(values={"a": 1.0}),
-        targets=Vector(values={"t": 2.0}),
-    )
-
-    line = serializer(sample)
-    assert '"kind": "Sample"' in line
-    assert '"key": ["2024-01-01T00:00:00Z"]' in line
-    assert '"fields": {"features.a": 1.0, "targets.t": 2.0}' in line
 
 
 def test_stdout_print_defaults_to_raw_view():


### PR DESCRIPTION
Summary
- replace output payload mode with output view semantics and unify output normalization
- replace numeric view with values (ordered keyless values, mixed primitive types)
- keep raw and flat views with format-aware defaults
- add and validate output encoding for fs jsonl/csv outputs
- improve CLI error guidance with an explicit output compatibility matrix
- dedupe shared record streams for early stage previews to avoid duplicate outputs

Docs
- update CLI/config docs and template references for flat/raw/values

Tests
- update/add unit coverage for output views, encoding validation, and stage preview dedupe
- remove one redundant serializer assertion test
- full suite: 147 passed

Notes
- This PR changes output-view naming (numeric -> values) and CSV view validation (flat or values).