### PR TITLE
Add ephemeral record stream cache

### DIFF
--- a/src/datapipeline/cache/__init__.py
+++ b/src/datapipeline/cache/__init__.py
@@ -1,0 +1,3 @@
+from .record_streams import RecordStreamCache, cached_record_stream
+
+__all__ = ["RecordStreamCache", "cached_record_stream"]

--- a/src/datapipeline/cache/contracts.py
+++ b/src/datapipeline/cache/contracts.py
@@ -1,0 +1,63 @@
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterator, Protocol
+
+from datapipeline.sources.models.source import Source
+
+
+@dataclass(frozen=True)
+class MaterializationRef:
+    kind: str
+    name: str
+    stage: str
+    signature_hash: str
+
+
+@dataclass(frozen=True)
+class MaterializationManifest:
+    version: int
+    kind: str
+    name: str
+    stage: str
+    signature_hash: str
+    relative_data_path: str
+    row_count: int
+    created_at: str
+
+    @classmethod
+    def create(
+        cls,
+        ref: MaterializationRef,
+        *,
+        data_path: Path,
+        root: Path,
+        row_count: int,
+    ) -> "MaterializationManifest":
+        return cls(
+            version=1,
+            kind=ref.kind,
+            name=ref.name,
+            stage=ref.stage,
+            signature_hash=ref.signature_hash,
+            relative_data_path=str(data_path.relative_to(root)),
+            row_count=row_count,
+            created_at=datetime.now(timezone.utc).isoformat(),
+        )
+
+    def as_json(self) -> dict[str, object]:
+        return asdict(self)
+
+
+class MaterializationStore(Protocol):
+    def load(self, ref: MaterializationRef) -> Source | None: ...
+
+    def materialize(
+        self,
+        ref: MaterializationRef,
+        items: Iterator[Any],
+    ) -> Iterator[Any]: ...
+
+
+class SourceObserver(Protocol):
+    def __call__(self, stream_source: Source, stream_id: str) -> Source: ...

--- a/src/datapipeline/cache/pickle_store.py
+++ b/src/datapipeline/cache/pickle_store.py
@@ -1,0 +1,152 @@
+import json
+from pathlib import Path
+from typing import Any, Iterator, Sequence
+
+from datapipeline.cache.contracts import (
+    MaterializationManifest,
+    MaterializationRef,
+)
+from datapipeline.io.writers.pickle_writer import PickleFileWriter
+from datapipeline.parsers.identity import IdentityParser
+from datapipeline.services.path_policy import sanitize_path_segment
+from datapipeline.sources.factory import build_loader
+from datapipeline.sources.models.loader import BaseDataLoader
+from datapipeline.sources.models.source import Source
+
+
+class PickleMaterializationStore:
+    def __init__(self, root: Path) -> None:
+        self._root = Path(root).resolve()
+
+    @property
+    def root(self) -> Path:
+        return self._root
+
+    def load(self, ref: MaterializationRef) -> Source | None:
+        manifest = self._load_manifest(ref)
+        if manifest is None:
+            return None
+        if manifest.signature_hash != ref.signature_hash:
+            return None
+        data_path = (self._root / manifest.relative_data_path).resolve()
+        if not data_path.exists():
+            return None
+        return self._source(ref, manifest, data_path)
+
+    def materialize(
+        self,
+        ref: MaterializationRef,
+        items: Iterator[Any],
+    ) -> Iterator[Any]:
+        data_path = self._data_path(ref)
+        manifest_path = self._manifest_path(ref)
+        writer = PickleFileWriter(data_path, serializer=lambda item: item)
+        row_count = 0
+        success = False
+        try:
+            for item in items:
+                writer.write(item)
+                row_count += 1
+                yield item
+            success = True
+        finally:
+            writer.close()
+            if not success:
+                data_path.unlink(missing_ok=True)
+                manifest_path.unlink(missing_ok=True)
+                return
+            manifest = MaterializationManifest.create(
+                ref,
+                data_path=data_path,
+                root=self._root,
+                row_count=row_count,
+            )
+            self._save_manifest(ref, manifest)
+
+    def _stream_dir(self, ref: MaterializationRef) -> Path:
+        return (
+            self._root
+            / sanitize_path_segment(ref.kind)
+            / sanitize_path_segment(ref.name)
+            / sanitize_path_segment(ref.stage)
+        )
+
+    def _data_path(self, ref: MaterializationRef) -> Path:
+        return (self._stream_dir(ref) / "data.pkl").resolve()
+
+    def _manifest_path(self, ref: MaterializationRef) -> Path:
+        return (self._stream_dir(ref) / "manifest.json").resolve()
+
+    def _load_manifest(
+        self,
+        ref: MaterializationRef,
+    ) -> MaterializationManifest | None:
+        path = self._manifest_path(ref)
+        if not path.exists():
+            return None
+        with path.open("r", encoding="utf-8") as handle:
+            data = json.load(handle)
+        if not isinstance(data, dict):
+            return None
+        try:
+            return MaterializationManifest(**data)
+        except TypeError:
+            return None
+
+    def _save_manifest(
+        self,
+        ref: MaterializationRef,
+        manifest: MaterializationManifest,
+    ) -> None:
+        path = self._manifest_path(ref)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("w", encoding="utf-8") as handle:
+            json.dump(manifest.as_json(), handle, indent=2, sort_keys=True)
+
+    @staticmethod
+    def _source(
+        ref: MaterializationRef,
+        manifest: MaterializationManifest,
+        path: Path,
+    ) -> Source:
+        base_loader = build_loader(transport="fs", format="pickle", path=str(path))
+        loader = _ObservedMaterializationLoader(
+            base_loader,
+            progress_label="Loading cache",
+        )
+        return Source(
+            loader=loader,
+            parser=IdentityParser(),
+        )
+
+
+class _ObservedMaterializationLoader(BaseDataLoader):
+    def __init__(
+        self,
+        inner: BaseDataLoader,
+        *,
+        progress_label: str | None = None,
+        info_lines: Sequence[str] = (),
+        debug_lines: Sequence[str] = (),
+    ) -> None:
+        self._inner = inner
+        self._progress_label = str(progress_label).strip() or None
+        self._info_lines = tuple(str(line) for line in info_lines if str(line).strip())
+        self._debug_lines = tuple(str(line) for line in debug_lines if str(line).strip())
+        self.transport = getattr(inner, "transport", None)
+        self.decoder = getattr(inner, "decoder", None)
+
+    def load(self) -> Iterator[Any]:
+        yield from self._inner.load()
+
+    def count(self) -> int | None:
+        return self._inner.count()
+
+    def info_lines(self) -> list[str]:
+        return list(self._info_lines)
+
+    def debug_lines(self) -> list[str]:
+        return list(self._debug_lines)
+
+    def progress_label(self) -> str | None:
+        return self._progress_label

--- a/src/datapipeline/cache/pickle_store.py
+++ b/src/datapipeline/cache/pickle_store.py
@@ -110,9 +110,14 @@ class PickleMaterializationStore:
         path: Path,
     ) -> Source:
         base_loader = build_loader(transport="fs", format="pickle", path=str(path))
+        logical_data_path = Path(manifest.relative_data_path).as_posix()
         loader = _ObservedMaterializationLoader(
             base_loader,
             progress_label="Loading cache",
+            info_lines=["Loaded contract output from cache"],
+            debug_lines=[f"cache.file: {logical_data_path}"],
+            include_transport_info=False,
+            include_transport_debug=False,
         )
         return Source(
             loader=loader,
@@ -128,11 +133,15 @@ class _ObservedMaterializationLoader(BaseDataLoader):
         progress_label: str | None = None,
         info_lines: Sequence[str] = (),
         debug_lines: Sequence[str] = (),
+        include_transport_info: bool = True,
+        include_transport_debug: bool = True,
     ) -> None:
         self._inner = inner
         self._progress_label = str(progress_label).strip() or None
         self._info_lines = tuple(str(line) for line in info_lines if str(line).strip())
         self._debug_lines = tuple(str(line) for line in debug_lines if str(line).strip())
+        self._include_transport_info = bool(include_transport_info)
+        self._include_transport_debug = bool(include_transport_debug)
         self.transport = getattr(inner, "transport", None)
         self.decoder = getattr(inner, "decoder", None)
 
@@ -150,3 +159,9 @@ class _ObservedMaterializationLoader(BaseDataLoader):
 
     def progress_label(self) -> str | None:
         return self._progress_label
+
+    def include_transport_info(self) -> bool:
+        return self._include_transport_info
+
+    def include_transport_debug(self) -> bool:
+        return self._include_transport_debug

--- a/src/datapipeline/cache/pickle_store.py
+++ b/src/datapipeline/cache/pickle_store.py
@@ -84,8 +84,11 @@ class PickleMaterializationStore:
         path = self._manifest_path(ref)
         if not path.exists():
             return None
-        with path.open("r", encoding="utf-8") as handle:
-            data = json.load(handle)
+        try:
+            with path.open("r", encoding="utf-8") as handle:
+                data = json.load(handle)
+        except json.JSONDecodeError:
+            return None
         if not isinstance(data, dict):
             return None
         try:

--- a/src/datapipeline/cache/record_streams.py
+++ b/src/datapipeline/cache/record_streams.py
@@ -69,6 +69,13 @@ def cached_record_stream(context, record_stream_id: str) -> Iterator[Any]:
     )
 
     runtime = context.runtime
+    if not getattr(runtime, "cache_enabled", True):
+        return build_record_pipeline(
+            context,
+            record_stream_id,
+            stage=RECORD_NODE_COUNT - 1,
+        )
+
     partition_by = runtime.registries.partition_by.get(record_stream_id)
     debug_operations = runtime.registries.debug_operations.get(record_stream_id)
 

--- a/src/datapipeline/cache/record_streams.py
+++ b/src/datapipeline/cache/record_streams.py
@@ -1,0 +1,95 @@
+from pathlib import Path
+from typing import Any, Iterator
+
+from datapipeline.cache.contracts import (
+    MaterializationRef,
+    MaterializationStore,
+    SourceObserver,
+)
+from datapipeline.cache.pickle_store import PickleMaterializationStore
+from datapipeline.cache.signatures import resolve_record_stream_signature
+
+_RECORD_STREAM_STAGE = "stream_transforms"
+
+
+class RecordStreamCache:
+    def __init__(
+        self,
+        *,
+        project_yaml: Path,
+        root: Path,
+        store: MaterializationStore | None = None,
+        source_observer: SourceObserver | None = None,
+    ) -> None:
+        self._project_yaml = Path(project_yaml).resolve()
+        self._store = store or PickleMaterializationStore(root)
+        self._signature_cache: dict[str, str | None] = {}
+        self._source_observer = source_observer or _default_source_observer
+
+    def load(self, stream_id: str) -> Iterator[Any] | None:
+        ref = self._materialization_ref(stream_id)
+        if ref is None:
+            return None
+        stream_source = self._store.load(ref)
+        if stream_source is None:
+            return None
+        return self._source_observer(stream_source, stream_id).stream()
+
+    def materialize(self, stream_id: str, items: Iterator[Any]) -> Iterator[Any]:
+        ref = self._materialization_ref(stream_id)
+        if ref is None:
+            yield from items
+            return
+        yield from self._store.materialize(ref, items)
+
+    def _materialization_ref(self, stream_id: str) -> MaterializationRef | None:
+        signature = self._signature(stream_id)
+        if signature is None:
+            return None
+        return MaterializationRef(
+            kind="record_stream",
+            name=stream_id,
+            stage=_RECORD_STREAM_STAGE,
+            signature_hash=signature,
+        )
+
+    def _signature(self, stream_id: str) -> str | None:
+        if stream_id in self._signature_cache:
+            return self._signature_cache[stream_id]
+        signature = resolve_record_stream_signature(self._project_yaml, stream_id)
+        self._signature_cache[stream_id] = signature
+        return signature
+
+
+def cached_record_stream(context, record_stream_id: str) -> Iterator[Any]:
+    from datapipeline.pipelines.record.dag import build_record_pipeline
+    from datapipeline.pipelines.record.nodes import (
+        RECORD_NODE_COUNT,
+        apply_debug_operations,
+    )
+
+    runtime = context.runtime
+    partition_by = runtime.registries.partition_by.get(record_stream_id)
+    debug_operations = runtime.registries.debug_operations.get(record_stream_id)
+
+    stream = runtime.record_stream_cache.load(record_stream_id)
+    if stream is None:
+        base_stream = build_record_pipeline(
+            context,
+            record_stream_id,
+            stage=RECORD_NODE_COUNT - 2,
+        )
+        stream = runtime.record_stream_cache.materialize(record_stream_id, base_stream)
+
+    return apply_debug_operations(
+        context,
+        debug_operations,
+        partition_by,
+        stream,
+    )
+def _default_source_observer(stream_source, stream_id: str):
+    try:
+        from datapipeline.cli.visuals.streams import observe_source
+    except Exception:
+        return stream_source
+    return observe_source(stream_source, stream_id)

--- a/src/datapipeline/cache/signatures.py
+++ b/src/datapipeline/cache/signatures.py
@@ -1,0 +1,67 @@
+import json
+from hashlib import sha256
+from pathlib import Path
+from typing import Any
+
+
+def resolve_record_stream_signature(
+    project_yaml: Path,
+    stream_id: str,
+) -> str | None:
+    payload = _record_stream_signature_payload(project_yaml, stream_id)
+    if payload is None:
+        return None
+    encoded = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    ).encode("utf-8")
+    return sha256(encoded).hexdigest()
+
+
+def _record_stream_signature_payload(
+    project_yaml: Path,
+    stream_id: str,
+) -> dict[str, Any] | None:
+    from datapipeline.services.bootstrap.core import load_streams
+
+    try:
+        streams = load_streams(project_yaml)
+    except Exception:
+        return None
+    return _stream_payload_from_config(streams, stream_id, {})
+
+
+def _stream_payload_from_config(
+    streams,
+    stream_id: str,
+    memo: dict[str, dict[str, Any]],
+) -> dict[str, Any] | None:
+    cached = memo.get(stream_id)
+    if cached is not None:
+        return cached
+
+    spec = streams.contracts.get(stream_id)
+    if spec is None:
+        return None
+
+    payload: dict[str, Any] = {
+        "contract": spec.model_dump(mode="json"),
+        "boundary": "record_stream:stream_transforms",
+    }
+    if spec.kind == "ingest":
+        if spec.source is not None and spec.source in streams.raw:
+            payload["source"] = streams.raw[spec.source].model_dump(mode="json")
+    else:
+        refs = [spec.parse_input_spec(item)[1] for item in list(spec.inputs or [])]
+        inputs: dict[str, Any] = {}
+        for ref in refs:
+            child = _stream_payload_from_config(streams, ref, memo)
+            if child is None:
+                return None
+            inputs[ref] = child
+        payload["inputs"] = inputs
+
+    memo[stream_id] = payload
+    return payload

--- a/src/datapipeline/cli/commands/profile_runner.py
+++ b/src/datapipeline/cli/commands/profile_runner.py
@@ -34,6 +34,7 @@ def handle_profile_command(
         output_directory=getattr(args, "output_directory", None),
         output_encoding=getattr(args, "output_encoding", None),
         output_view=getattr(args, "output_view", None),
+        cli_cache=getattr(args, "cache", None),
         skip_build=getattr(args, "skip_build", False),
         cli_log_level=cli_level_arg,
         cli_log_outputs=cli_log_outputs,
@@ -46,4 +47,3 @@ def handle_profile_command(
         return True
     run_profiles(request)
     return True
-

--- a/src/datapipeline/cli/parser/common.py
+++ b/src/datapipeline/cli/parser/common.py
@@ -29,6 +29,23 @@ def add_visual_flags(parser: argparse.ArgumentParser) -> None:
     )
 
 
+def add_cache_flags(parser: argparse.ArgumentParser) -> None:
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
+        "--cache",
+        dest="cache",
+        action="store_true",
+        default=None,
+        help="enable runtime record-stream caching",
+    )
+    group.add_argument(
+        "--no-cache",
+        dest="cache",
+        action="store_false",
+        help="disable runtime record-stream caching",
+    )
+
+
 def build_common_parent() -> argparse.ArgumentParser:
     common = argparse.ArgumentParser(add_help=False)
     common.add_argument(

--- a/src/datapipeline/cli/parser/inspect.py
+++ b/src/datapipeline/cli/parser/inspect.py
@@ -7,7 +7,7 @@ from datapipeline.config.options import (
 )
 from datapipeline.config.profiles import VALID_BUILD_MODES
 
-from .common import add_dataset_flag, add_project_flag, add_visual_flags
+from .common import add_cache_flags, add_dataset_flag, add_project_flag, add_visual_flags
 
 
 def add_inspect_command(sub, common: argparse.ArgumentParser) -> None:
@@ -65,3 +65,4 @@ def add_inspect_command(sub, common: argparse.ArgumentParser) -> None:
         help="artifact build policy when the selected profile target is an artifact task: AUTO | FORCE | OFF",
     )
     add_visual_flags(parser)
+    add_cache_flags(parser)

--- a/src/datapipeline/cli/parser/serve.py
+++ b/src/datapipeline/cli/parser/serve.py
@@ -3,7 +3,7 @@ import argparse
 from datapipeline.config.options import OUTPUT_FORMATS, OUTPUT_TRANSPORTS, OUTPUT_VIEWS
 from datapipeline.config.profiles import VALID_BUILD_MODES
 
-from .common import add_dataset_flag, add_project_flag, add_visual_flags
+from .common import add_cache_flags, add_dataset_flag, add_project_flag, add_visual_flags
 
 
 def add_serve_command(sub,  common: argparse.ArgumentParser) -> None:
@@ -60,6 +60,7 @@ def add_serve_command(sub,  common: argparse.ArgumentParser) -> None:
         help="preview up to a 0-based feature-pipeline node index",
     )
     add_visual_flags(parser)
+    add_cache_flags(parser)
     parser.add_argument(
         "--skip-build",
         action="store_true",

--- a/src/datapipeline/cli/visuals/execution_context.py
+++ b/src/datapipeline/cli/visuals/execution_context.py
@@ -22,6 +22,10 @@ _CURRENT_EXECUTION_SCOPE: ContextVar[dict[str, str] | None] = ContextVar(
     "datapipeline_visual_current_execution_scope",
     default=None,
 )
+_CURRENT_SOURCE_VISUAL_PROXY_FACTORY: ContextVar[Any | None] = ContextVar(
+    "datapipeline_visual_current_source_visual_proxy_factory",
+    default=None,
+)
 
 
 def set_current_dag_depth(depth: int) -> None:
@@ -82,6 +86,18 @@ def reset_current_execution_scope(token) -> None:
 
 def current_execution_scope() -> dict[str, str] | None:
     return _CURRENT_EXECUTION_SCOPE.get()
+
+
+def set_current_source_visual_proxy_factory(factory: Any | None):
+    return _CURRENT_SOURCE_VISUAL_PROXY_FACTORY.set(factory)
+
+
+def reset_current_source_visual_proxy_factory(token) -> None:
+    _CURRENT_SOURCE_VISUAL_PROXY_FACTORY.reset(token)
+
+
+def current_source_visual_proxy_factory() -> Any | None:
+    return _CURRENT_SOURCE_VISUAL_PROXY_FACTORY.get()
 
 
 def visible_dag_depth(level: int) -> int:

--- a/src/datapipeline/cli/visuals/labels.py
+++ b/src/datapipeline/cli/visuals/labels.py
@@ -1,24 +1,35 @@
 from datapipeline.sources.models.loader import SyntheticLoader, BaseDataLoader
-from datapipeline.sources.data_loader import DataLoader
 from datapipeline.sources.foreach import ForeachLoader
 from datapipeline.sources.adapters.fs import FsFileTransport, FsGlobTransport
 from datapipeline.sources.adapters.http import HttpTransport
 from datapipeline.sources.decoders import CsvDecoder, JsonDecoder, JsonLinesDecoder, PickleDecoder
 
 
+def _transport_for_loader(loader):
+    return getattr(loader, "transport", None)
+
+
+def _decoder_for_loader(loader):
+    return getattr(loader, "decoder", None)
+
+
 def unit_for_loader(loader) -> str:
     if isinstance(loader, SyntheticLoader):
         return "tick"
-    if isinstance(loader, DataLoader):
-        dec = getattr(loader, "decoder", None)
-        if isinstance(dec, CsvDecoder):
-            return "row"
-        if isinstance(dec, (JsonDecoder, JsonLinesDecoder, PickleDecoder)):
-            return "item"
+    dec = _decoder_for_loader(loader)
+    if dec is None:
+        return "record"
+    if isinstance(dec, CsvDecoder):
+        return "row"
+    if isinstance(dec, (JsonDecoder, JsonLinesDecoder, PickleDecoder)):
+        return "item"
     return "record"
 
 
 def build_source_label(loader: BaseDataLoader) -> str:
+    custom = _custom_progress_label(loader)
+    if custom is not None:
+        return custom
     if isinstance(loader, SyntheticLoader):
         try:
             gen_name = loader.generator.__class__.__name__
@@ -30,14 +41,27 @@ def build_source_label(loader: BaseDataLoader) -> str:
         values = getattr(loader, "_values", None)
         n = len(values) if isinstance(values, list) else "?"
         return f"Fan-out {key}×{n}:"
-    if isinstance(loader, DataLoader):
-        transport = getattr(loader, "transport", None)
-        if isinstance(transport, (FsFileTransport, FsGlobTransport)):
-            return "Loading"
-        if isinstance(transport, HttpTransport):
-            return "Downloading"
+    if _decoder_for_loader(loader) is None:
+        return loader.__class__.__name__
+    transport = _transport_for_loader(loader)
+    if isinstance(transport, (FsFileTransport, FsGlobTransport)):
+        return "Loading"
+    if isinstance(transport, HttpTransport):
+        return "Downloading"
     return loader.__class__.__name__
 
 
 def progress_meta_for_loader(loader: BaseDataLoader) -> tuple[str, str]:
     return build_source_label(loader), unit_for_loader(loader)
+
+
+def _custom_progress_label(loader) -> str | None:
+    producer = getattr(loader, "progress_label", None)
+    if not callable(producer):
+        return None
+    try:
+        value = producer()
+    except Exception:
+        return None
+    text = str(value).strip() if value is not None else ""
+    return text or None

--- a/src/datapipeline/cli/visuals/rich/sources.py
+++ b/src/datapipeline/cli/visuals/rich/sources.py
@@ -93,11 +93,14 @@ class _RichSourceProxy(Source):
         adapter = SourceObservabilityAdapter(self._inner, self._stream_id)
         stream_label = self._stream_id
         task_id: Optional[int] = None
+        progress_visible = getattr(adapter, "progress_visible", lambda: True)()
         sequence_entries = getattr(adapter, "progress_sequence", lambda: None)()
         sequence_index = 0
         task_emitted = 0
         retired_task_ids: list[int] = []
-        info_lines = [str(line).strip() for line in adapter.info_lines() if str(line).strip()]
+        info_lines = [
+            str(line).rstrip() for line in adapter.info_lines() if str(line).strip()
+        ]
         initial_message = adapter.format_label(
             include_stream_id=False,
             include_dag_indent=False,
@@ -123,14 +126,15 @@ class _RichSourceProxy(Source):
         last_path_label: Optional[str] = initial_path_label
 
         try:
-            total = adapter.count()
-            if sequence_entries:
-                total = sequence_entries[0].total
-            task_id = self._start_task(
-                text=self._format_text(stream_label, initial_message),
-                total=total,
-            )
-            self._safe_progress_call("refresh progress", self._progress.refresh)
+            if progress_visible:
+                total = adapter.count()
+                if sequence_entries:
+                    total = sequence_entries[0].total
+                task_id = self._start_task(
+                    text=self._format_text(stream_label, initial_message),
+                    total=total,
+                )
+                self._safe_progress_call("refresh progress", self._progress.refresh)
 
             for item in self._inner.stream():
                 current_label = adapter.current_label()

--- a/src/datapipeline/cli/visuals/rich/sources.py
+++ b/src/datapipeline/cli/visuals/rich/sources.py
@@ -17,10 +17,12 @@ from ..execution import emit_execution_message
 from ..execution_context import (
     current_dag_depth,
     reset_current_execution_event_sink,
+    reset_current_source_visual_proxy_factory,
     reset_current_terminal_log_proxy_sink,
     reset_current_visual_log_level,
     set_current_dag_depth,
     set_current_execution_event_sink,
+    set_current_source_visual_proxy_factory,
     set_current_terminal_log_proxy_sink,
     set_current_visual_log_level,
     visible_dag_indent,
@@ -239,6 +241,13 @@ def visual_sources(runtime: Runtime, log_level: int | None):
     level_token = set_current_visual_log_level(level)
     execution_sink_token = set_current_execution_event_sink(execution_sink)
     proxy_token = set_current_terminal_log_proxy_sink(execution_sink)
+    source_proxy_token = set_current_source_visual_proxy_factory(
+        lambda stream_source, stream_id: _RichSourceProxy(
+            stream_source=stream_source,
+            stream_id=stream_id,
+            progress=progress,
+        )
+    )
 
     try:
         with progress:
@@ -265,6 +274,7 @@ def visual_sources(runtime: Runtime, log_level: int | None):
         finally:
             reset_current_terminal_log_proxy_sink(proxy_token)
             reset_current_execution_event_sink(execution_sink_token)
+            reset_current_source_visual_proxy_factory(source_proxy_token)
             reset_current_visual_log_level(level_token)
 
 

--- a/src/datapipeline/cli/visuals/runner.py
+++ b/src/datapipeline/cli/visuals/runner.py
@@ -20,6 +20,7 @@ def _run_work(backend, runtime: Runtime, level: int, work: Callable[[], Any]):
         with backend.wrap_sources(runtime, level):
             return work()
     finally:
+        runtime.cleanup_cache()
         if installed:
             runtime.execution_observer = previous_observer
 

--- a/src/datapipeline/cli/visuals/source_observability.py
+++ b/src/datapipeline/cli/visuals/source_observability.py
@@ -124,7 +124,8 @@ class SourceObservabilityAdapter:
         lines.extend(self.composed_detail_lines())
         if observability.info_lines:
             lines.extend(observability.info_lines)
-        lines.extend(transport_info_lines(observability.transport))
+        if self._include_transport_info():
+            lines.extend(transport_info_lines(observability.transport))
         return lines
 
     def debug_lines(self) -> list[str]:
@@ -132,7 +133,8 @@ class SourceObservabilityAdapter:
         lines: list[str] = []
         if observability.debug_lines:
             lines.extend(observability.debug_lines)
-        lines.extend(transport_debug_lines(observability.transport))
+        if self._include_transport_debug():
+            lines.extend(transport_debug_lines(observability.transport))
         return lines
 
     def current_indent(self, level: int = logging.INFO) -> str:
@@ -140,6 +142,24 @@ class SourceObservabilityAdapter:
 
     def progress_visible(self) -> bool:
         producer = getattr(self.loader, "progress_visible", None)
+        if not callable(producer):
+            return True
+        try:
+            return bool(producer())
+        except Exception:
+            return True
+
+    def _include_transport_info(self) -> bool:
+        producer = getattr(self.loader, "include_transport_info", None)
+        if not callable(producer):
+            return True
+        try:
+            return bool(producer())
+        except Exception:
+            return True
+
+    def _include_transport_debug(self) -> bool:
+        producer = getattr(self.loader, "include_transport_debug", None)
         if not callable(producer):
             return True
         try:

--- a/src/datapipeline/cli/visuals/source_observability.py
+++ b/src/datapipeline/cli/visuals/source_observability.py
@@ -1,6 +1,6 @@
+import logging
 from dataclasses import dataclass
 from typing import Any, Optional
-import logging
 
 from datapipeline.sources.data_loader import DataLoader
 from datapipeline.sources.foreach import ForeachLoader
@@ -16,7 +16,6 @@ from .common import (
     compute_glob_root,
     current_transport_label,
     relative_label,
-    log_combined_stream,
     transport_debug_lines,
     transport_info_lines,
 )
@@ -54,15 +53,22 @@ class SourceObservabilityAdapter:
     def composed_inputs(self) -> Optional[list[str]]:
         return describe_loader(self.loader).composed_inputs
 
-    def log_composed_details(self, level: int = logging.INFO) -> None:
+    def composed_detail_lines(self) -> list[str]:
         details = self.composed_inputs()
         if not details:
-            return
-        log_combined_stream(
-            self.stream_id,
-            details,
-            indent=self.current_indent(level),
-        )
+            return []
+        parts: list[str] = []
+        for entry in details:
+            left, sep, right = str(entry).partition("=")
+            if sep:
+                parts.append(f"{left.strip()}={right.strip()}")
+            else:
+                text = str(entry).strip()
+                if text:
+                    parts.append(text)
+        if not parts:
+            return []
+        return [f"Composed from: {', '.join(parts)}"]
 
     def current_label(self) -> Optional[str]:
         observability = describe_loader(self.loader)
@@ -115,6 +121,7 @@ class SourceObservabilityAdapter:
     def info_lines(self) -> list[str]:
         observability = describe_loader(self.loader)
         lines: list[str] = []
+        lines.extend(self.composed_detail_lines())
         if observability.info_lines:
             lines.extend(observability.info_lines)
         lines.extend(transport_info_lines(observability.transport))
@@ -130,6 +137,15 @@ class SourceObservabilityAdapter:
 
     def current_indent(self, level: int = logging.INFO) -> str:
         return visible_dag_indent(level)
+
+    def progress_visible(self) -> bool:
+        producer = getattr(self.loader, "progress_visible", None)
+        if not callable(producer):
+            return True
+        try:
+            return bool(producer())
+        except Exception:
+            return True
 
     def format_label(
         self,

--- a/src/datapipeline/cli/visuals/streams.py
+++ b/src/datapipeline/cli/visuals/streams.py
@@ -4,6 +4,9 @@ import sys
 from typing import Optional, Tuple
 
 from datapipeline.runtime import Runtime
+from datapipeline.sources.models.source import Source
+
+from .execution_context import current_source_visual_proxy_factory
 
 
 def _is_tty() -> bool:
@@ -131,6 +134,13 @@ def get_visuals_backend(provider: Optional[str]) -> VisualsBackend:
     if _rich_available() and _is_tty() and _rich_live_supported():
         return _RichBackend()
     return _BasicBackend()
+
+
+def observe_source(stream_source: Source, stream_id: str):
+    factory = current_source_visual_proxy_factory()
+    if factory is None:
+        return stream_source
+    return factory(stream_source, stream_id)
 
 
 @contextmanager

--- a/src/datapipeline/cli/visuals/streams_basic.py
+++ b/src/datapipeline/cli/visuals/streams_basic.py
@@ -27,23 +27,29 @@ class VisualSourceProxy(Source):
         adapter = SourceObservabilityAdapter(self._inner, self._stream_id)
         emitted = 0
         started = False
+
+        def _emit_source_details() -> None:
+            info_indent = adapter.current_indent(logging.INFO)
+            debug_indent = adapter.current_indent(logging.DEBUG)
+            info_lines = adapter.info_lines()
+            debug_lines = adapter.debug_lines()
+            if logger.isEnabledFor(logging.INFO):
+                if info_lines:
+                    for line in info_lines:
+                        logger.info("%s[%s] %s", info_indent, self._stream_id, line)
+                else:
+                    logger.info("%s[%s] Stream starting", info_indent, self._stream_id)
+            if logger.isEnabledFor(logging.DEBUG):
+                for line in debug_lines:
+                    logger.debug("%s[%s] %s", debug_indent, self._stream_id, line)
+
         try:
+            if not getattr(adapter, "progress_visible", lambda: True)():
+                _emit_source_details()
+                started = True
             for item in self._inner.stream():
                 if not started:
-                    info_indent = adapter.current_indent(logging.INFO)
-                    debug_indent = adapter.current_indent(logging.DEBUG)
-                    adapter.log_composed_details(logging.INFO)
-                    info_lines = adapter.info_lines()
-                    debug_lines = adapter.debug_lines()
-                    if logger.isEnabledFor(logging.INFO):
-                        if info_lines:
-                            for line in info_lines:
-                                logger.info("%s[%s] %s", info_indent, self._stream_id, line)
-                        else:
-                            logger.info("%s[%s] Stream starting", info_indent, self._stream_id)
-                    if logger.isEnabledFor(logging.DEBUG):
-                        for line in debug_lines:
-                            logger.debug("%s[%s] %s", debug_indent, self._stream_id, line)
+                    _emit_source_details()
                     started = True
                 emitted += 1
                 yield item

--- a/src/datapipeline/cli/visuals/streams_basic.py
+++ b/src/datapipeline/cli/visuals/streams_basic.py
@@ -7,7 +7,9 @@ from datapipeline.sources.models.source import Source
 
 from .source_observability import SourceObservabilityAdapter
 from .execution_context import (
+    reset_current_source_visual_proxy_factory,
     reset_current_visual_log_level,
+    set_current_source_visual_proxy_factory,
     set_current_visual_log_level,
 )
 
@@ -64,6 +66,9 @@ def visual_sources(runtime: Runtime, log_level: int | None):
     reg = runtime.registries.stream_sources
     originals = dict(reg.items())
     level_token = set_current_visual_log_level(level)
+    proxy_token = set_current_source_visual_proxy_factory(
+        lambda stream_source, stream_id: VisualSourceProxy(stream_source, stream_id)
+    )
     try:
         for stream_id, stream_source in originals.items():
             reg.register(stream_id, VisualSourceProxy(stream_source, stream_id))
@@ -71,4 +76,5 @@ def visual_sources(runtime: Runtime, log_level: int | None):
     finally:
         for stream_id, stream_source in originals.items():
             reg.register(stream_id, stream_source)
+        reset_current_source_visual_proxy_factory(proxy_token)
         reset_current_visual_log_level(level_token)

--- a/src/datapipeline/config/profiles/defaults.py
+++ b/src/datapipeline/config/profiles/defaults.py
@@ -19,6 +19,7 @@ class ProfileDefaults(BaseModel):
 
 class ServeProfileDefaults(ProfileDefaults):
     cmd: Literal["serve"]
+    cache: bool | None = None
     output: ServeOutputConfig | None = None
     observability: ObservabilityConfig | None = Field(default=None)
     build: RuntimeBuildConfig | None = Field(default=None)
@@ -41,6 +42,7 @@ class BuildProfileDefaults(ProfileDefaults):
 
 class InspectProfileDefaults(ProfileDefaults):
     cmd: Literal["inspect"]
+    cache: bool | None = None
     output: ServeOutputConfig | None = None
     observability: ObservabilityConfig | None = Field(default=None)
     build: RuntimeBuildConfig | None = Field(default=None)

--- a/src/datapipeline/config/profiles/inspect.py
+++ b/src/datapipeline/config/profiles/inspect.py
@@ -12,6 +12,7 @@ from .runtime_build import RuntimeBuildConfig
 class InspectProfile(Profile):
     cmd: Literal["inspect"]
     target: str
+    cache: bool | None = None
     output: ServeOutputConfig | None = None
     observability: ObservabilityConfig | None = Field(default=None)
     build: RuntimeBuildConfig | None = Field(default=None)

--- a/src/datapipeline/config/profiles/serve.py
+++ b/src/datapipeline/config/profiles/serve.py
@@ -12,6 +12,7 @@ from .runtime_build import RuntimeBuildConfig
 class ServeProfile(Profile):
     cmd: Literal["serve"]
     target: str
+    cache: bool | None = None
     output: ServeOutputConfig | None = None
     observability: ObservabilityConfig | None = Field(default=None)
     build: RuntimeBuildConfig | None = Field(default=None)

--- a/src/datapipeline/config/serve_resolution.py
+++ b/src/datapipeline/config/serve_resolution.py
@@ -40,6 +40,7 @@ class RunProfile:
     stage: Optional[int]
     limit: Optional[int]
     throttle_ms: Optional[float]
+    cache_enabled: bool
     log_decision: LogLevelDecision
     log_output: LogOutputSettings
     visuals: VisualSettings
@@ -59,10 +60,11 @@ def resolve_run_profiles(
     limit: Optional[int],
     cli_build_mode: Optional[str],
     cli_output,
-    cli_log_level: Optional[str],
+    cli_log_level: Optional[str] = None,
     cli_log_outputs: Sequence[LogOutputTarget] | None = None,
     base_log_level: str = "INFO",
     cli_visuals: Optional[str] = None,
+    cli_cache: Optional[bool] = None,
 ) -> list[RunProfile]:
     fallback_log_level = str(base_log_level).upper()
     cli_log_output_candidates = list(cli_log_outputs or [])
@@ -83,6 +85,7 @@ def resolve_run_profiles(
 
         resolved_stage = cascade(stage, _run_config_value(run_cfg, "stage"))
         resolved_limit = cascade(limit, _run_config_value(run_cfg, "limit"))
+        resolved_cache = bool(cascade(cli_cache, _run_config_value(run_cfg, "cache"), True))
         run_cmd = getattr(run_cfg, "cmd", None)
         create_run = run_cmd == "serve"
         if resolved_stage is not None and not create_run:
@@ -94,6 +97,7 @@ def resolve_run_profiles(
                 f"Runtime profile '{run_label}' does not support keep filters."
             )
         throttle_ms = _run_config_value(run_cfg, "throttle_ms")
+        runtime.cache_enabled = resolved_cache
         log_decision = resolve_log_level(
             cli_log_level,
             logging_value(run_observability, "level"),
@@ -142,6 +146,7 @@ def resolve_run_profiles(
                 stage=resolved_stage,
                 limit=resolved_limit,
                 throttle_ms=throttle_ms,
+                cache_enabled=resolved_cache,
                 log_decision=log_decision,
                 log_output=log_output,
                 visuals=visuals,

--- a/src/datapipeline/pipelines/feature/dag.py
+++ b/src/datapipeline/pipelines/feature/dag.py
@@ -1,6 +1,7 @@
 from collections.abc import Iterator
 from typing import Any, Mapping
 
+from datapipeline.cache import cached_record_stream
 from datapipeline.config.dataset.feature import FeatureRecordConfig
 from datapipeline.dag.dag import StageDag
 from datapipeline.dag.runner import run_stage_dag
@@ -19,15 +20,33 @@ def build_feature_pipeline(
     cfg: FeatureRecordConfig,
     stage: int | None = None,
 ) -> Iterator[Any]:
+    metadata = _feature_dag_metadata(
+        record_stream_id=cfg.record_stream,
+        feature_id=cfg.id,
+        field=cfg.field,
+        scale=cfg.scale,
+        sequence=cfg.sequence,
+    )
+    if stage is None:
+        record_stream = cached_record_stream(context, cfg.record_stream)
+        dag = StageDag(
+            name=f"feature:{cfg.id}",
+            metadata=metadata,
+            nodes=build_feature_nodes(
+                context,
+                record_stream_id=cfg.record_stream,
+                feature_id=cfg.id,
+                field=cfg.field,
+                scale=cfg.scale,
+                sequence=cfg.sequence,
+                record_input="seed",
+            ),
+        )
+        return run_stage_dag(context, dag, seed=record_stream)
+
     dag = StageDag(
         name=f"feature:{cfg.id}",
-        metadata=_feature_dag_metadata(
-            record_stream_id=cfg.record_stream,
-            feature_id=cfg.id,
-            field=cfg.field,
-            scale=cfg.scale,
-            sequence=cfg.sequence,
-        ),
+        metadata=metadata,
         nodes=(
             *build_record_nodes(context, cfg.record_stream),
             *build_feature_nodes(
@@ -74,6 +93,7 @@ def build_feature_nodes(
     field: str,
     scale: Mapping[str, Any] | bool | None,
     sequence: Mapping[str, Any] | None,
+    record_input: str = "stream_transforms",
 ) -> tuple[PipelineStep, ...]:
     partition_by = context.runtime.registries.partition_by.get(record_stream_id)
     batch_size = context.runtime.registries.sort_batch_size.get(record_stream_id)
@@ -82,7 +102,7 @@ def build_feature_nodes(
             name="build_feature_stream",
             op=build_feature_stream,
             args=(feature_id, field, partition_by),
-            input="stream_transforms",
+            input=record_input,
         ),
         PipelineStep(
             name="feature_transforms",

--- a/src/datapipeline/profiles/models.py
+++ b/src/datapipeline/profiles/models.py
@@ -34,6 +34,7 @@ class ExecutionProfile:
     limit: int | None = None
     output: OutputTarget | None = None
     throttle_ms: float | None = None
+    cache_enabled: bool = True
     stage: int | None = None
     build_mode: str | None = None
     build_settings: BuildSettings | None = None

--- a/src/datapipeline/profiles/orchestration.py
+++ b/src/datapipeline/profiles/orchestration.py
@@ -73,6 +73,8 @@ def _shared_cache_root(
         return None
     if len(profiles) <= 1:
         return None
+    if not any(getattr(profile, "cache_enabled", True) for profile in profiles):
+        return None
     project_name = request.project_path.stem or "project"
     return Path(
         tempfile.mkdtemp(prefix=f"datapipeline-cache-{project_name}-")

--- a/src/datapipeline/profiles/orchestration.py
+++ b/src/datapipeline/profiles/orchestration.py
@@ -1,6 +1,11 @@
+import shutil
+import tempfile
+from pathlib import Path
+
 from datapipeline.profiles.executor import ProfileExecutionSpec, run_profile
 from datapipeline.cli.visuals.execution import execution_scope
 from datapipeline.services.bootstrap import bootstrap
+from datapipeline.runtime import Runtime
 from .execution import execute_profile
 from .models import ProfileRunRequest
 from .reporting import persist_profile_report
@@ -12,42 +17,63 @@ def run_profiles(request: ProfileRunRequest) -> None:
     if not profiles:
         return
 
-    total = len(profiles)
-    for idx, profile in enumerate(profiles, start=1):
-        runtime = profile.runtime or bootstrap(request.project_path)
-        profile_path = persist_profile_report(
-            profile_kind=request.command,
-            profile=profile,
-            payload=profile.profile_report,
-        )
-        spec = ProfileExecutionSpec(
-            command=request.command,
-            name=profile.name,
-            idx=idx,
-            total=total,
-            visuals=profile.visuals or "on",
-            log_decision=profile.log_decision,
-            log_output=profile.log_output,
-            sections=profile.sections,
-            label=profile.label or profile.name,
-            runtime=runtime,
-            use_visual_runner=True,
-            profile_path=profile_path,
-        )
-
-        def work(profile=profile, runtime=runtime):
-            scope_target = profile.target_id
-            with execution_scope(
+    shared_cache_root = _shared_cache_root(request, profiles)
+    try:
+        total = len(profiles)
+        for idx, profile in enumerate(profiles, start=1):
+            runtime = profile.runtime or bootstrap(request.project_path)
+            if shared_cache_root is not None and isinstance(runtime, Runtime):
+                runtime.set_cache_root(shared_cache_root, owned=False)
+            profile_path = persist_profile_report(
                 profile_kind=request.command,
-                profile_name=profile.name,
-                target_id=scope_target,
-                announce=False,
-            ):
-                return execute_profile(
-                    profile=profile,
-                    request=request,
-                    tasks_by_id=tasks_by_id,
-                    runtime_override=runtime,
-                )
+                profile=profile,
+                payload=profile.profile_report,
+            )
+            spec = ProfileExecutionSpec(
+                command=request.command,
+                name=profile.name,
+                idx=idx,
+                total=total,
+                visuals=profile.visuals or "on",
+                log_decision=profile.log_decision,
+                log_output=profile.log_output,
+                sections=profile.sections,
+                label=profile.label or profile.name,
+                runtime=runtime,
+                use_visual_runner=True,
+                profile_path=profile_path,
+            )
 
-        run_profile(spec=spec, work=work)
+            def work(profile=profile, runtime=runtime):
+                scope_target = profile.target_id
+                with execution_scope(
+                    profile_kind=request.command,
+                    profile_name=profile.name,
+                    target_id=scope_target,
+                    announce=False,
+                ):
+                    return execute_profile(
+                        profile=profile,
+                        request=request,
+                        tasks_by_id=tasks_by_id,
+                        runtime_override=runtime,
+                    )
+
+            run_profile(spec=spec, work=work)
+    finally:
+        if shared_cache_root is not None:
+            shutil.rmtree(shared_cache_root, ignore_errors=True)
+
+
+def _shared_cache_root(
+    request: ProfileRunRequest,
+    profiles,
+) -> Path | None:
+    if request.command not in {"serve", "inspect"}:
+        return None
+    if len(profiles) <= 1:
+        return None
+    project_name = request.project_path.stem or "project"
+    return Path(
+        tempfile.mkdtemp(prefix=f"datapipeline-cache-{project_name}-")
+    ).resolve()

--- a/src/datapipeline/profiles/reporting.py
+++ b/src/datapipeline/profiles/reporting.py
@@ -22,6 +22,7 @@ def runtime_profile_report_payload(profile) -> dict[str, object]:
         "stage": profile.stage,
         "limit": profile.limit,
         "throttle_ms": profile.throttle_ms,
+        "cache_enabled": profile.cache_enabled,
         "log_level": {
             "name": profile.log_decision.name,
             "value": profile.log_decision.value,

--- a/src/datapipeline/profiles/request_builder.py
+++ b/src/datapipeline/profiles/request_builder.py
@@ -65,6 +65,7 @@ class ProfileResolveParams:
     output_directory: Optional[str]
     output_encoding: Optional[str]
     output_view: Optional[str]
+    cli_cache: Optional[bool]
     skip_build: bool
     cli_log_level: Optional[str]
     cli_log_outputs: Sequence[LogOutputTarget] | None
@@ -210,6 +211,7 @@ def _resolve_runtime_execution_profiles(
             limit=params.limit,
             cli_build_mode=params.build_mode,
             cli_output=cli_output_cfg,
+            cli_cache=params.cli_cache,
             cli_log_level=params.cli_log_level,
             cli_log_outputs=params.cli_log_outputs,
             base_log_level=params.base_log_level,
@@ -245,6 +247,7 @@ def _resolve_runtime_execution_profiles(
                 limit=profile.limit,
                 output=profile.output,
                 throttle_ms=profile.throttle_ms,
+                cache_enabled=profile.cache_enabled,
                 stage=profile.stage,
                 build_mode=profile.build_mode,
             )
@@ -267,6 +270,7 @@ def build_profile_run_request(
     output_directory: Optional[str] = None,
     output_encoding: Optional[str] = None,
     output_view: Optional[str] = None,
+    cli_cache: Optional[bool] = None,
     skip_build: bool = False,
     cli_log_level: Optional[str] = None,
     cli_log_outputs: Sequence[LogOutputTarget] | None = None,
@@ -296,6 +300,7 @@ def build_profile_run_request(
         output_directory=output_directory,
         output_encoding=output_encoding,
         output_view=output_view,
+        cli_cache=cli_cache,
         skip_build=skip_build,
         cli_log_level=cli_log_level,
         cli_log_outputs=cli_log_outputs,

--- a/src/datapipeline/runtime.py
+++ b/src/datapipeline/runtime.py
@@ -68,6 +68,7 @@ class Runtime:
     project_yaml: Path
     artifacts_root: Path
     cache_root: Path | None = None
+    cache_enabled: bool = True
     registries: Registries = field(default_factory=Registries)
     split: Optional[SplitConfig] = None
     split_keep: Optional[str] = None

--- a/src/datapipeline/runtime.py
+++ b/src/datapipeline/runtime.py
@@ -1,8 +1,11 @@
 from dataclasses import dataclass, field
+import shutil
+import tempfile
 from pathlib import Path
 from typing import Any, List, Mapping, Optional, Sequence, Union
 from datetime import datetime
 
+from datapipeline.cache import RecordStreamCache
 from datapipeline.config.profiles import ServeProfile
 from datapipeline.config.split import SplitConfig
 
@@ -64,6 +67,7 @@ class Runtime:
 
     project_yaml: Path
     artifacts_root: Path
+    cache_root: Path | None = None
     registries: Registries = field(default_factory=Registries)
     split: Optional[SplitConfig] = None
     split_keep: Optional[str] = None
@@ -71,6 +75,46 @@ class Runtime:
     schema_required: bool = True
     window_bounds: tuple[datetime | None, datetime | None] | None = None
     artifacts: ArtifactManager = field(init=False)
+    record_stream_cache: RecordStreamCache = field(init=False)
+    _owns_cache_root: bool = field(init=False, repr=False, default=False)
 
     def __post_init__(self) -> None:
         self.artifacts = ArtifactManager(self.artifacts_root)
+        self.cache_root = self._resolve_cache_root(self.cache_root)
+        self.record_stream_cache = RecordStreamCache(
+            project_yaml=self.project_yaml,
+            root=self.cache_root,
+        )
+
+    def cleanup_cache(self) -> None:
+        cache_root = self.cache_root
+        if not self._owns_cache_root or cache_root is None:
+            return
+        shutil.rmtree(cache_root, ignore_errors=True)
+
+    def set_cache_root(self, root: Path, *, owned: bool = False) -> None:
+        current = self.cache_root
+        if self._owns_cache_root and current is not None and current != root:
+            shutil.rmtree(current, ignore_errors=True)
+        resolved = Path(root).resolve()
+        resolved.mkdir(parents=True, exist_ok=True)
+        self.cache_root = resolved
+        self._owns_cache_root = bool(owned)
+        self.record_stream_cache = RecordStreamCache(
+            project_yaml=self.project_yaml,
+            root=resolved,
+        )
+
+    def _resolve_cache_root(self, configured: Path | None) -> Path:
+        if configured is not None:
+            root = Path(configured).resolve()
+            root.mkdir(parents=True, exist_ok=True)
+            self._owns_cache_root = False
+            return root
+
+        project_name = self.project_yaml.stem or "project"
+        root = Path(
+            tempfile.mkdtemp(prefix=f"datapipeline-cache-{project_name}-")
+        ).resolve()
+        self._owns_cache_root = True
+        return root

--- a/src/datapipeline/services/factories.py
+++ b/src/datapipeline/services/factories.py
@@ -1,11 +1,10 @@
 from typing import Any, Iterator
 
+from datapipeline.cache import cached_record_stream
 from datapipeline.config.catalog import ContractConfig, EPArgs, SourceConfig
 from datapipeline.dag.context import PipelineContext
 from datapipeline.mappers.noop import identity
 from datapipeline.parsers.identity import IdentityParser
-from datapipeline.pipelines import build_record_pipeline
-from datapipeline.pipelines.record.nodes import RECORD_NODE_COUNT
 from datapipeline.plugins import LOADERS_EP, MAPPERS_EP, PARSERS_EP
 from datapipeline.sources.models.loader import BaseDataLoader
 from datapipeline.sources.models.source import Source
@@ -93,8 +92,7 @@ class _ComposedLoader(BaseDataLoader):
     def _resolve_inputs(self, context: PipelineContext, specs: list[str]):
         """Parse and resolve composed inputs into iterators.
 
-        Grammar: "[alias=]stream_id" only. All inputs are built to stage 4
-        with stream transforms applied.
+        Grammar: "[alias=]stream_id" only.
         """
         runtime = context.runtime
         known_streams = set(runtime.registries.stream_sources.keys())
@@ -106,11 +104,7 @@ class _ComposedLoader(BaseDataLoader):
                 raise ValueError(
                     f"Unknown input stream '{ref}'. Known streams: {sorted(known_streams)}"
                 )
-            out[alias] = build_record_pipeline(
-                context,
-                ref,
-                stage=RECORD_NODE_COUNT - 1,
-            )
+            out[alias] = cached_record_stream(context, ref)
 
         return out
 

--- a/src/datapipeline/services/factories.py
+++ b/src/datapipeline/services/factories.py
@@ -1,4 +1,5 @@
-from typing import Any, Iterator
+from collections.abc import Iterator
+from typing import Any
 
 from datapipeline.cache import cached_record_stream
 from datapipeline.config.catalog import ContractConfig, EPArgs, SourceConfig
@@ -44,10 +45,15 @@ class _ComposedLoader(BaseDataLoader):
         if not input_specs:
             return
 
-        input_iters: dict[str, Iterator[Any]] = {
-            alias: (getattr(item, "record", item) for item in iterator)
-            for alias, iterator in self._resolve_inputs(context, input_specs).items()
-        }
+        resolved_inputs = self._resolve_inputs(context, input_specs)
+        upstream_iters: list[Iterator[Any]] = []
+        input_iters: dict[str, Iterator[Any]] = {}
+        for alias, iterator in resolved_inputs.items():
+            upstream_iter = iter(iterator)
+            upstream_iters.append(upstream_iter)
+            input_iters[alias] = (
+                getattr(item, "record", item) for item in upstream_iter
+            )
 
         mapper = self._spec.mapper
         if not mapper or not mapper.entrypoint:
@@ -82,12 +88,20 @@ class _ComposedLoader(BaseDataLoader):
                 "`mapper(inputs, *, context, driver, **params)`"
             ) from exc
 
-        for rec in composed_records:
-            yield getattr(rec, "record", rec)
+        try:
+            for rec in composed_records:
+                yield getattr(rec, "record", rec)
+        finally:
+            _close_iterator(composed_records)
+            for iterator in upstream_iters:
+                _close_iterator(iterator)
 
     def count(self):
         # Compose/join logic may change cardinality; unknown by design.
         return None
+
+    def progress_visible(self) -> bool:
+        return False
 
     def _resolve_inputs(self, context: PipelineContext, specs: list[str]):
         """Parse and resolve composed inputs into iterators.
@@ -121,3 +135,9 @@ def build_composed_source(stream_id: str, spec: ContractConfig, runtime) -> Sour
         loader=_ComposedLoader(runtime=runtime, stream_id=stream_id, spec=spec),
         parser=IdentityParser(),
     )
+
+
+def _close_iterator(iterator: Any) -> None:
+    closer = getattr(iterator, "close", None)
+    if callable(closer):
+        closer()

--- a/src/datapipeline/sources/observability.py
+++ b/src/datapipeline/sources/observability.py
@@ -27,7 +27,21 @@ def describe_loader(loader: Any) -> LoaderObservability:
         composed_inputs=_coerce_inputs(
             getattr(getattr(loader, "_spec", None), "inputs", None)
         ),
+        info_lines=_loader_lines(loader, "info_lines"),
+        debug_lines=_loader_lines(loader, "debug_lines"),
     )
+
+
+def _loader_lines(loader: Any, attr: str) -> list[str] | None:
+    producer = getattr(loader, attr, None)
+    if not callable(producer):
+        return None
+    try:
+        values = list(producer() or [])
+    except Exception:
+        return None
+    lines = [str(value).strip() for value in values if str(value).strip()]
+    return lines or None
 
 
 def _describe_foreach_loader(loader: ForeachLoader) -> LoaderObservability:

--- a/src/datapipeline/transforms/vector/ensure_schema.py
+++ b/src/datapipeline/transforms/vector/ensure_schema.py
@@ -42,6 +42,13 @@ class VectorEnsureSchemaTransform(VectorContextMixin):
     def __call__(self, stream: Iterator[Sample]) -> Iterator[Sample]:
         return self.apply(stream)
 
+    def bind_context(self, context) -> None:
+        super().bind_context(context)
+        # Snapshot schema entries when the transform is wired up so lazy stream
+        # iteration cannot observe a later artifact/context mismatch.
+        if self._schema_entries is None:
+            self._schema_entries = context.load_schema(payload=self._payload) or []
+
     def apply(self, stream: Iterator[Sample]) -> Iterator[Sample]:
         baseline = self._schema_ids()
         baseline_set = set(baseline)

--- a/tests/unit/cli/test_run_cli.py
+++ b/tests/unit/cli/test_run_cli.py
@@ -112,6 +112,113 @@ def test_run_profiles_default_build_mode_is_auto(monkeypatch, tmp_path):
     assert profiles[0].build_mode == "AUTO"
 
 
+def test_run_profiles_default_cache_enabled(monkeypatch, tmp_path):
+    entries = [_entry(name="demo", config=None, operation=_SERVE_OPERATION)]
+
+    def fake_iter_runtime_runs(project_path, run_entries, keep):
+        total = len(run_entries)
+        for idx, entry in enumerate(run_entries, start=1):
+            runtime = SimpleNamespace(run=entry.config)
+            yield idx, total, entry, runtime
+
+    monkeypatch.setattr(
+        "datapipeline.config.serve_resolution.iter_runtime_runs", fake_iter_runtime_runs
+    )
+
+    profiles = resolve_run_profiles(
+        project_path=tmp_path,
+        run_entries=entries,
+        keep=None,
+        stage=None,
+        limit=None,
+        cli_build_mode=None,
+        cli_output=None,
+        cli_log_level=None,
+        base_log_level="INFO",
+        cli_visuals=None,
+    )
+
+    assert profiles[0].cache_enabled is True
+    assert profiles[0].runtime.cache_enabled is True
+
+
+def test_run_profiles_profile_cache_false(monkeypatch, tmp_path):
+    run_cfg = ServeProfile.model_validate(
+        {
+            "cmd": "serve",
+            "name": "demo",
+            "target": "serve",
+            "cache": False,
+        }
+    )
+    entries = [_entry(name="demo", config=run_cfg, operation=_SERVE_OPERATION)]
+
+    def fake_iter_runtime_runs(project_path, run_entries, keep):
+        total = len(run_entries)
+        for idx, entry in enumerate(run_entries, start=1):
+            runtime = SimpleNamespace(run=entry.config)
+            yield idx, total, entry, runtime
+
+    monkeypatch.setattr(
+        "datapipeline.config.serve_resolution.iter_runtime_runs", fake_iter_runtime_runs
+    )
+
+    profiles = resolve_run_profiles(
+        project_path=tmp_path,
+        run_entries=entries,
+        keep=None,
+        stage=None,
+        limit=None,
+        cli_build_mode=None,
+        cli_output=None,
+        cli_log_level=None,
+        base_log_level="INFO",
+        cli_visuals=None,
+    )
+
+    assert profiles[0].cache_enabled is False
+    assert profiles[0].runtime.cache_enabled is False
+
+
+def test_run_profiles_cli_cache_overrides_profile(monkeypatch, tmp_path):
+    run_cfg = ServeProfile.model_validate(
+        {
+            "cmd": "serve",
+            "name": "demo",
+            "target": "serve",
+            "cache": False,
+        }
+    )
+    entries = [_entry(name="demo", config=run_cfg, operation=_SERVE_OPERATION)]
+
+    def fake_iter_runtime_runs(project_path, run_entries, keep):
+        total = len(run_entries)
+        for idx, entry in enumerate(run_entries, start=1):
+            runtime = SimpleNamespace(run=entry.config)
+            yield idx, total, entry, runtime
+
+    monkeypatch.setattr(
+        "datapipeline.config.serve_resolution.iter_runtime_runs", fake_iter_runtime_runs
+    )
+
+    profiles = resolve_run_profiles(
+        project_path=tmp_path,
+        run_entries=entries,
+        keep=None,
+        stage=None,
+        limit=None,
+        cli_build_mode=None,
+        cli_output=None,
+        cli_log_level=None,
+        base_log_level="INFO",
+        cli_visuals=None,
+        cli_cache=True,
+    )
+
+    assert profiles[0].cache_enabled is True
+    assert profiles[0].runtime.cache_enabled is True
+
+
 def test_operation_contract_rejects_stage_when_unsupported(monkeypatch, tmp_path):
     run_cfg = InspectProfile.model_validate(
         {

--- a/tests/unit/cli/test_run_config.py
+++ b/tests/unit/cli/test_run_config.py
@@ -82,6 +82,32 @@ def test_serve_request_resolves_targeted_profile(monkeypatch, tmp_path: Path):
     assert any(task.id == "coverage" for task in request.tasks)
 
 
+def test_serve_request_resolves_cache_cli_override(monkeypatch, tmp_path: Path):
+    _patch_runtime_resolution(monkeypatch)
+    project_yaml = _write_project(tmp_path)
+    ops = tmp_path / "tasks" / "operations"
+    profiles = tmp_path / "profiles"
+    ops.mkdir(parents=True, exist_ok=True)
+    profiles.mkdir(parents=True, exist_ok=True)
+
+    _write_op(
+        ops / "pipeline.yaml",
+        "id: pipeline\nkind: runtime\nentrypoint: core.runtime.pipeline\n",
+    )
+    (profiles / "serve.train.yaml").write_text(
+        "cmd: serve\nname: train\ntarget: pipeline\ncache: false\n",
+        encoding="utf-8",
+    )
+
+    request = build_profile_run_request(
+        kind="serve",
+        project=str(project_yaml),
+        cli_cache=True,
+    )
+    assert request is not None
+    assert request.profiles[0].cache_enabled is True
+
+
 def test_inspect_request_defaults_to_enabled_profiles(monkeypatch, tmp_path: Path):
     _patch_runtime_resolution(monkeypatch)
     project_yaml = _write_project(tmp_path)

--- a/tests/unit/cli/test_source_observability.py
+++ b/tests/unit/cli/test_source_observability.py
@@ -1,12 +1,8 @@
 from dataclasses import dataclass
-import logging
-
 import pytest
 
 from datapipeline.cli.visuals.execution_context import (
-    reset_current_visual_log_level,
     set_current_dag_depth,
-    set_current_visual_log_level,
 )
 from datapipeline.cli.visuals.source_observability import SourceObservabilityAdapter
 from datapipeline.sources.data_loader import DataLoader
@@ -83,6 +79,9 @@ class _ComposedLoader:
     def count(self):
         return None
 
+    def progress_visible(self):
+        return False
+
 
 class _ComposedSourceWithLoader:
     def __init__(self):
@@ -129,60 +128,25 @@ def test_source_observability_adapter_includes_synthetic_info_line():
 
 
 
-def test_source_observability_adapter_logs_composed_details(monkeypatch):
-    captured: list[tuple[str, list[str] | None, str]] = []
-
-    def _capture(stream_id, details, indent=""):
-        captured.append((stream_id, details, indent))
-
-    monkeypatch.setattr(
-        "datapipeline.cli.visuals.source_observability.log_combined_stream",
-        _capture,
-    )
-
-    set_current_dag_depth(2)
+def test_source_observability_adapter_includes_composed_details_in_info_lines():
     adapter = SourceObservabilityAdapter(_ComposedSourceWithLoader(), "combined")
-    adapter.log_composed_details()
 
-    assert captured == [("combined", ["a=left", "b=right"], "    ")]
+    assert adapter.info_lines() == [
+        "Composed from: a=left, b=right",
+    ]
 
 
+def test_source_observability_adapter_uses_loader_progress_visibility():
+    adapter = SourceObservabilityAdapter(_ComposedSourceWithLoader(), "combined")
 
-def test_source_observability_adapter_skips_composed_details_for_non_composed(monkeypatch):
-    captured: list[tuple[str, list[str] | None, str]] = []
-
-    def _capture(stream_id, details, indent=""):
-        captured.append((stream_id, details, indent))
-
-    monkeypatch.setattr(
-        "datapipeline.cli.visuals.source_observability.log_combined_stream",
-        _capture,
-    )
-
-    adapter = SourceObservabilityAdapter(_SourceWithLoader(), "demo")
-    adapter.log_composed_details()
-
-    assert captured == []
+    assert adapter.progress_visible() is False
 
 
 def test_source_observability_adapter_formats_with_current_dag_indent():
     set_current_dag_depth(2)
     adapter = SourceObservabilityAdapter(_SourceWithLoader(), "demo")
     assert adapter.current_indent() == "    "
-    assert adapter.current_indent(logging.DEBUG) == "    "
     assert adapter.format_label() == "    [demo] _DummyLoader"
-    assert adapter.format_label(level=logging.DEBUG) == "    [demo] _DummyLoader"
-
-
-def test_source_observability_adapter_uses_full_depth_in_debug_session():
-    set_current_dag_depth(2)
-    token = set_current_visual_log_level(logging.DEBUG)
-    try:
-        adapter = SourceObservabilityAdapter(_SourceWithLoader(), "demo")
-        assert adapter.current_indent(logging.INFO) == "    "
-        assert adapter.current_indent(logging.DEBUG) == "    "
-    finally:
-        reset_current_visual_log_level(token)
 
 
 def test_source_observability_adapter_initial_label_uses_first_glob_file():

--- a/tests/unit/cli/test_streams_basic.py
+++ b/tests/unit/cli/test_streams_basic.py
@@ -1,5 +1,8 @@
 import logging
+from types import SimpleNamespace
 
+from datapipeline.cli.visuals.streams import observe_source
+from datapipeline.cli.visuals.streams_basic import visual_sources
 from datapipeline.cli.visuals.streams_basic import VisualSourceProxy
 from datapipeline.sources.models.generator import DataGenerator
 from datapipeline.sources.models.loader import SyntheticLoader
@@ -27,6 +30,17 @@ class _SyntheticSource:
         yield from self.loader.load()
 
 
+class _StreamRegistry:
+    def __init__(self) -> None:
+        self._items: dict[str, object] = {}
+
+    def items(self):
+        return self._items.items()
+
+    def register(self, stream_id: str, stream_source: object) -> None:
+        self._items[stream_id] = stream_source
+
+
 def test_visual_source_proxy_logs_ascii_stream_completion(caplog):
     proxy = VisualSourceProxy(_SyntheticSource(), "time.ticks.linear")
 
@@ -41,3 +55,14 @@ def test_visual_source_proxy_logs_ascii_stream_completion(caplog):
         for msg in messages
     )
     assert all("✔" not in msg for msg in messages)
+
+
+def test_basic_visual_sources_observe_dynamic_sources() -> None:
+    runtime = SimpleNamespace(
+        registries=SimpleNamespace(stream_sources=_StreamRegistry())
+    )
+
+    with visual_sources(runtime, logging.INFO):
+        observed = observe_source(_SyntheticSource(), "time.ticks.linear")
+
+    assert isinstance(observed, VisualSourceProxy)

--- a/tests/unit/cli/test_streams_rich.py
+++ b/tests/unit/cli/test_streams_rich.py
@@ -509,6 +509,66 @@ def test_rich_source_proxy_emits_glob_summary_as_source_info_event(monkeypatch) 
     )
 
 
+def test_rich_source_proxy_skips_progress_row_for_virtual_source(monkeypatch) -> None:
+    captured: list[tuple[str, int, int, str | None]] = []
+    monkeypatch.setattr(
+        "datapipeline.cli.visuals.rich.sources.emit_execution_message",
+        lambda message, level, logger, depth=0, message_kind=None: captured.append(
+            (message, level, depth, message_kind)
+        ),
+    )
+
+    class _Adapter:
+        def info_lines(self):
+            return ["Composed from: aapl=equity.aapl, msft=equity.msft"]
+
+        def format_label(self, name=None, **kwargs):
+            if name:
+                return f"Loading {name}"
+            return "ComposedLoader"
+
+        def initial_label(self):
+            return None
+
+        def count(self):
+            return None
+
+        def current_label(self):
+            return None
+
+        def progress_visible(self):
+            return False
+
+    monkeypatch.setattr(
+        "datapipeline.cli.visuals.rich.sources.SourceObservabilityAdapter",
+        lambda stream_source, stream_id: _Adapter(),
+    )
+
+    progress = _RecordingProgress()
+    source = SimpleNamespace(stream=lambda: iter([1]))
+    proxy = _RichSourceProxy(
+        stream_source=source,
+        stream_id="equity.pair.aapl_msft",
+        progress=progress,
+    )
+
+    set_current_dag_depth(2)
+    try:
+        list(proxy.stream())
+    finally:
+        set_current_dag_depth(0)
+
+    assert progress.added_texts == []
+    assert captured[:1] == [
+        (
+            "[equity.pair.aapl_msft] Composed from: aapl=equity.aapl, msft=equity.msft",
+            logging.INFO,
+            2,
+            "source_info",
+        ),
+    ]
+
+
 def test_rich_source_proxy_tracks_glob_file_transitions_as_progress_rows(monkeypatch) -> None:
     class _Adapter:
         def __init__(self):

--- a/tests/unit/cli/test_streams_rich.py
+++ b/tests/unit/cli/test_streams_rich.py
@@ -27,6 +27,7 @@ from datapipeline.cli.visuals.rich.sources import (
     _clear_progress_tasks,
     visual_sources,
 )
+from datapipeline.cli.visuals.streams import observe_source
 from datapipeline.sources.models.generator import DataGenerator
 from datapipeline.sources.foreach import ForeachLoader
 from datapipeline.sources.models.loader import BaseDataLoader, SyntheticLoader
@@ -887,3 +888,14 @@ def test_visual_sources_runs_central_task_cleanup_on_interrupt(monkeypatch) -> N
             raise KeyboardInterrupt()
 
     assert called["count"] == 1
+
+
+def test_rich_visual_sources_observe_dynamic_sources() -> None:
+    runtime = SimpleNamespace(
+        registries=SimpleNamespace(stream_sources=_StreamRegistry())
+    )
+
+    with visual_sources(runtime, logging.INFO):
+        observed = observe_source(_SyntheticSource(), "time.ticks.linear")
+
+    assert isinstance(observed, _RichSourceProxy)

--- a/tests/unit/cli/test_visuals_runner.py
+++ b/tests/unit/cli/test_visuals_runner.py
@@ -53,3 +53,56 @@ def test_run_with_backend_executes_work():
             work=lambda: called.__setitem__("ok", True),
         )
     assert called["ok"] is True
+
+
+def test_run_job_cleans_runtime_cache_on_success():
+    backend = _StubBackend()
+    runtime = _runtime()
+    calls = {"cleanup": 0}
+
+    def _cleanup():
+        calls["cleanup"] += 1
+
+    runtime.cleanup_cache = _cleanup  # type: ignore[method-assign]
+
+    with patch("datapipeline.cli.visuals.runner.get_visuals_backend", return_value=backend):
+        runner.run_job(
+            sections=("Runs",),
+            label="demo",
+            visuals="on",
+            level=logging.INFO,
+            runtime=runtime,
+            work=lambda: None,
+            idx=1,
+            total=1,
+        )
+
+    assert calls["cleanup"] == 1
+
+
+def test_run_job_cleans_runtime_cache_on_failure():
+    backend = _StubBackend()
+    runtime = _runtime()
+    calls = {"cleanup": 0}
+
+    def _cleanup():
+        calls["cleanup"] += 1
+
+    runtime.cleanup_cache = _cleanup  # type: ignore[method-assign]
+
+    with patch("datapipeline.cli.visuals.runner.get_visuals_backend", return_value=backend):
+        try:
+            runner.run_job(
+                sections=("Runs",),
+                label="demo",
+                visuals="on",
+                level=logging.INFO,
+                runtime=runtime,
+                work=lambda: (_ for _ in ()).throw(RuntimeError("boom")),
+                idx=1,
+                total=1,
+            )
+        except RuntimeError:
+            pass
+
+    assert calls["cleanup"] == 1

--- a/tests/unit/pipeline/test_record_stream_cache.py
+++ b/tests/unit/pipeline/test_record_stream_cache.py
@@ -1,0 +1,230 @@
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+from datapipeline.cache.record_streams import RecordStreamCache, cached_record_stream
+from datapipeline.dag.context import PipelineContext
+from datapipeline.domain.record import TemporalRecord
+from datapipeline.runtime import Runtime
+from datapipeline.services.bootstrap.config import artifacts_root
+
+
+@dataclass
+class _Rec(TemporalRecord):
+    symbol: str
+    value: float
+
+
+def _ts(day: int) -> datetime:
+    return datetime(2021, 1, day, tzinfo=timezone.utc)
+
+
+def _write_project(tmp_path: Path, *, partition_by: str | None = None) -> Path:
+    project_root = tmp_path / "project"
+    (project_root / "sources").mkdir(parents=True)
+    (project_root / "contracts").mkdir(parents=True)
+    (project_root / "tasks").mkdir(parents=True)
+    (project_root / "profiles").mkdir(parents=True)
+
+    (project_root / "dataset.yaml").write_text("group_by: 1d\nfeatures: []\n", encoding="utf-8")
+    (project_root / "postprocess.yaml").write_text("[]\n", encoding="utf-8")
+    (project_root / "project.yaml").write_text(
+        "\n".join(
+            [
+                "version: 1",
+                "name: demo",
+                "paths:",
+                "  streams: ./contracts",
+                "  sources: ./sources",
+                "  dataset: ./dataset.yaml",
+                "  postprocess: ./postprocess.yaml",
+                "  artifacts: ./artifacts",
+                "  tasks: ./tasks",
+                "  profiles: ./profiles",
+                "globals: {}",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (project_root / "sources" / "raw.aapl.yaml").write_text(
+        "\n".join(
+            [
+                "id: raw.aapl",
+                "parser:",
+                "  entrypoint: identity",
+                "loader:",
+                "  entrypoint: fs",
+                "  args:",
+                "    transport: fs",
+                "    format: pickle",
+                "    path: ./data/raw.pkl",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    contract_lines = [
+        "kind: ingest",
+        "id: prices.aapl",
+        "source: raw.aapl",
+        "mapper:",
+        "  entrypoint: identity",
+        "record: []",
+        "stream: []",
+        "debug: []",
+    ]
+    if partition_by is not None:
+        contract_lines.append(f"partition_by: {partition_by}")
+    contract_lines.append("")
+    (project_root / "contracts" / "prices.aapl.yaml").write_text(
+        "\n".join(contract_lines),
+        encoding="utf-8",
+    )
+    return project_root / "project.yaml"
+
+
+def test_record_stream_cache_materializes_and_replays(tmp_path: Path) -> None:
+    project_yaml = _write_project(tmp_path)
+    cache = RecordStreamCache(
+        project_yaml=project_yaml,
+        root=(artifacts_root(project_yaml) / "_system" / "cache").resolve(),
+    )
+    records = [
+        _Rec(time=_ts(1), symbol="AAPL", value=1.0),
+        _Rec(time=_ts(2), symbol="AAPL", value=2.0),
+    ]
+
+    materialized = list(cache.materialize("prices.aapl", iter(records)))
+    replayed = list(cache.load("prices.aapl") or ())
+
+    assert materialized == records
+    assert replayed == records
+
+
+def test_record_stream_cache_invalidates_when_contract_changes(tmp_path: Path) -> None:
+    project_yaml = _write_project(tmp_path)
+    cache = RecordStreamCache(
+        project_yaml=project_yaml,
+        root=(artifacts_root(project_yaml) / "_system" / "cache").resolve(),
+    )
+    list(cache.materialize("prices.aapl", iter([_Rec(time=_ts(1), symbol="AAPL", value=1.0)])))
+
+    contract_path = project_yaml.parent / "contracts" / "prices.aapl.yaml"
+    contract_path.write_text(
+        contract_path.read_text(encoding="utf-8") + "partition_by: symbol\n",
+        encoding="utf-8",
+    )
+
+    invalidated = RecordStreamCache(
+        project_yaml=project_yaml,
+        root=(artifacts_root(project_yaml) / "_system" / "cache").resolve(),
+    )
+    assert invalidated.load("prices.aapl") is None
+
+
+def test_cached_record_stream_reuses_cache_without_rebuilding(tmp_path: Path, monkeypatch) -> None:
+    project_yaml = _write_project(tmp_path)
+    runtime = Runtime(
+        project_yaml=project_yaml,
+        artifacts_root=artifacts_root(project_yaml),
+    )
+    runtime.registries.partition_by.register("prices.aapl", None)
+    runtime.registries.debug_operations.register("prices.aapl", [])
+    context = PipelineContext(runtime)
+    records = [
+        _Rec(time=_ts(1), symbol="AAPL", value=1.0),
+        _Rec(time=_ts(2), symbol="AAPL", value=2.0),
+    ]
+    calls = {"count": 0}
+
+    def _build(*args, **kwargs):
+        calls["count"] += 1
+        return iter(records)
+
+    monkeypatch.setattr("datapipeline.pipelines.record.dag.build_record_pipeline", _build)
+
+    first = list(cached_record_stream(context, "prices.aapl"))
+    second = list(cached_record_stream(context, "prices.aapl"))
+
+    assert first == records
+    assert second == records
+    assert calls["count"] == 1
+
+
+def test_record_stream_cache_load_observes_source_visuals(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    project_yaml = _write_project(tmp_path)
+    cache = RecordStreamCache(
+        project_yaml=project_yaml,
+        root=(artifacts_root(project_yaml) / "_system" / "cache").resolve(),
+    )
+    records = [_Rec(time=_ts(1), symbol="AAPL", value=1.0)]
+    list(cache.materialize("prices.aapl", iter(records)))
+
+    captured: dict[str, str] = {}
+
+    def _observe(source, stream_id):
+        captured["stream_id"] = stream_id
+        return source
+
+    monkeypatch.setattr("datapipeline.cli.visuals.streams.observe_source", _observe)
+
+    replayed = list(cache.load("prices.aapl") or ())
+
+    assert replayed == records
+    assert captured == {"stream_id": "prices.aapl"}
+
+
+def test_record_stream_cache_loader_exposes_cache_progress_label(tmp_path: Path) -> None:
+    project_yaml = _write_project(tmp_path)
+    cache = RecordStreamCache(
+        project_yaml=project_yaml,
+        root=(artifacts_root(project_yaml) / "_system" / "cache").resolve(),
+    )
+    records = [_Rec(time=_ts(1), symbol="AAPL", value=1.0)]
+    list(cache.materialize("prices.aapl", iter(records)))
+
+    ref = cache._materialization_ref("prices.aapl")
+    assert ref is not None
+    source = cache._store.load(ref)
+
+    assert source is not None
+    assert source.loader.progress_label() == "Loading cache"
+
+
+def test_runtime_uses_owned_temp_cache_root_and_cleans_it(tmp_path: Path) -> None:
+    project_yaml = _write_project(tmp_path)
+    runtime = Runtime(
+        project_yaml=project_yaml,
+        artifacts_root=artifacts_root(project_yaml),
+    )
+
+    cache_root = runtime.cache_root
+
+    assert cache_root is not None
+    assert cache_root.exists()
+    assert runtime._owns_cache_root is True
+
+    runtime.cleanup_cache()
+
+    assert not cache_root.exists()
+
+
+def test_runtime_preserves_explicit_cache_root(tmp_path: Path) -> None:
+    project_yaml = _write_project(tmp_path)
+    cache_root = tmp_path / "cache"
+    runtime = Runtime(
+        project_yaml=project_yaml,
+        artifacts_root=artifacts_root(project_yaml),
+        cache_root=cache_root,
+    )
+
+    assert runtime.cache_root == cache_root.resolve()
+    assert runtime._owns_cache_root is False
+
+    runtime.cleanup_cache()
+
+    assert cache_root.exists()

--- a/tests/unit/pipeline/test_record_stream_cache.py
+++ b/tests/unit/pipeline/test_record_stream_cache.py
@@ -123,6 +123,22 @@ def test_record_stream_cache_invalidates_when_contract_changes(tmp_path: Path) -
     assert invalidated.load("prices.aapl") is None
 
 
+def test_record_stream_cache_treats_malformed_manifest_as_cache_miss(tmp_path: Path) -> None:
+    project_yaml = _write_project(tmp_path)
+    cache = RecordStreamCache(
+        project_yaml=project_yaml,
+        root=(artifacts_root(project_yaml) / "_system" / "cache").resolve(),
+    )
+    list(cache.materialize("prices.aapl", iter([_Rec(time=_ts(1), symbol="AAPL", value=1.0)])))
+
+    ref = cache._materialization_ref("prices.aapl")
+    assert ref is not None
+    manifest_path = cache._store._manifest_path(ref)
+    manifest_path.write_text('{"signature_hash": ', encoding="utf-8")
+
+    assert cache.load("prices.aapl") is None
+
+
 def test_cached_record_stream_reuses_cache_without_rebuilding(tmp_path: Path, monkeypatch) -> None:
     project_yaml = _write_project(tmp_path)
     runtime = Runtime(

--- a/tests/unit/pipeline/test_record_stream_cache.py
+++ b/tests/unit/pipeline/test_record_stream_cache.py
@@ -193,6 +193,12 @@ def test_record_stream_cache_loader_exposes_cache_progress_label(tmp_path: Path)
 
     assert source is not None
     assert source.loader.progress_label() == "Loading cache"
+    assert source.loader.info_lines() == ["Loaded contract output from cache"]
+    assert source.loader.debug_lines() == [
+        "cache.file: record_stream/prices.aapl/stream_transforms/data.pkl"
+    ]
+    assert source.loader.include_transport_info() is False
+    assert source.loader.include_transport_debug() is False
 
 
 def test_runtime_uses_owned_temp_cache_root_and_cleans_it(tmp_path: Path) -> None:

--- a/tests/unit/pipeline/test_record_stream_cache.py
+++ b/tests/unit/pipeline/test_record_stream_cache.py
@@ -228,3 +228,34 @@ def test_runtime_preserves_explicit_cache_root(tmp_path: Path) -> None:
     runtime.cleanup_cache()
 
     assert cache_root.exists()
+
+
+def test_cached_record_stream_bypasses_cache_when_disabled(tmp_path: Path, monkeypatch) -> None:
+    project_yaml = _write_project(tmp_path)
+    runtime = Runtime(
+        project_yaml=project_yaml,
+        artifacts_root=artifacts_root(project_yaml),
+    )
+    runtime.cache_enabled = False
+    runtime.registries.partition_by.register("prices.aapl", None)
+    runtime.registries.debug_operations.register("prices.aapl", [])
+    context = PipelineContext(runtime)
+    records = [
+        _Rec(time=_ts(1), symbol="AAPL", value=1.0),
+        _Rec(time=_ts(2), symbol="AAPL", value=2.0),
+    ]
+    calls = {"count": 0, "stage": None}
+
+    def _build(*args, **kwargs):
+        calls["count"] += 1
+        calls["stage"] = kwargs.get("stage")
+        return iter(records)
+
+    monkeypatch.setattr("datapipeline.pipelines.record.dag.build_record_pipeline", _build)
+
+    first = list(cached_record_stream(context, "prices.aapl"))
+    second = list(cached_record_stream(context, "prices.aapl"))
+
+    assert first == records
+    assert second == records
+    assert calls["count"] == 2

--- a/tests/unit/profiles/test_orchestration.py
+++ b/tests/unit/profiles/test_orchestration.py
@@ -5,6 +5,7 @@ from datapipeline.build.state import BuildState, save_build_state
 from datapipeline.config.tasks import MetadataTask, OperationTask, SchemaTask
 from datapipeline.profiles.models import ExecutionProfile, ProfileRunRequest
 from datapipeline.profiles.orchestration import run_profiles
+from datapipeline.runtime import Runtime
 from datapipeline.services.artifacts import ArtifactManager
 from datapipeline.services.bootstrap import build_state_path
 from datapipeline.services.constants import VECTOR_SCHEMA
@@ -344,3 +345,63 @@ def test_runtime_dependency_build_scope_isolated_from_parent_profile(monkeypatch
     run_profiles(request)
 
     assert captured["count"] == 0
+
+
+def test_run_profiles_share_ephemeral_cache_root_across_runtime_profiles(
+    monkeypatch,
+    tmp_path,
+):
+    serve = OperationTask.model_validate(
+        {
+            "id": "pipeline",
+            "kind": "runtime",
+            "entrypoint": "core.runtime.pipeline",
+        }
+    )
+    project_yaml = tmp_path / "project.yaml"
+    runtime_one = Runtime(project_yaml=project_yaml, artifacts_root=tmp_path / "artifacts")
+    runtime_two = Runtime(project_yaml=project_yaml, artifacts_root=tmp_path / "artifacts")
+    log_decision, log_output = _log_config()
+    request = ProfileRunRequest(
+        command="serve",
+        project_path=project_yaml,
+        tasks=[serve],
+        artifact_task_configs=[],
+        profiles=[
+            ExecutionProfile(
+                name="train",
+                target_id="pipeline",
+                visuals="on",
+                log_decision=log_decision,
+                log_output=log_output,
+                runtime=runtime_one,
+                dataset=object(),
+            ),
+            ExecutionProfile(
+                name="val",
+                target_id="pipeline",
+                visuals="on",
+                log_decision=log_decision,
+                log_output=log_output,
+                runtime=runtime_two,
+                dataset=object(),
+            ),
+        ],
+    )
+
+    seen_roots = []
+
+    monkeypatch.setattr(
+        "datapipeline.profiles.orchestration.run_profile",
+        lambda spec, work: work(),
+    )
+    monkeypatch.setattr(
+        "datapipeline.profiles.execution.execute_operation",
+        lambda **kwargs: seen_roots.append(kwargs["runtime"].cache_root),
+    )
+
+    run_profiles(request)
+
+    assert len(seen_roots) == 2
+    assert seen_roots[0] == seen_roots[1]
+    assert not seen_roots[0].exists()

--- a/tests/unit/services/test_factories.py
+++ b/tests/unit/services/test_factories.py
@@ -1,0 +1,68 @@
+from types import SimpleNamespace
+
+from datapipeline.config.catalog import ContractConfig, EPArgs
+from datapipeline.services.factories import _ComposedLoader
+
+
+class _Registry:
+    def __init__(self, keys: list[str]) -> None:
+        self._keys = tuple(keys)
+
+    def keys(self):
+        return self._keys
+
+
+class _ClosableIterator:
+    def __init__(self, values):
+        self._values = iter(values)
+        self.closed = 0
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        return next(self._values)
+
+    def close(self):
+        self.closed += 1
+
+
+def test_composed_loader_closes_upstream_iterators_when_closed(monkeypatch) -> None:
+    upstream = _ClosableIterator([1, 2, 3])
+
+    def _cached_record_stream(_context, _ref):
+        return upstream
+
+    def _mapper(inputs, *, context, driver, **params):
+        del context
+        del params
+        yield from inputs[driver]
+
+    monkeypatch.setattr(
+        "datapipeline.services.factories.cached_record_stream",
+        _cached_record_stream,
+    )
+    monkeypatch.setattr(
+        "datapipeline.services.factories.load_ep",
+        lambda _namespace, _entrypoint: _mapper,
+    )
+
+    runtime = SimpleNamespace(
+        registries=SimpleNamespace(
+            stream_sources=_Registry(["equity.aapl"]),
+        )
+    )
+    spec = ContractConfig(
+        kind="composed",
+        id="equity.pair.aapl",
+        inputs=["aapl=equity.aapl"],
+        mapper=EPArgs(entrypoint="test.mapper", args={}),
+    )
+    loader = _ComposedLoader(runtime=runtime, stream_id=spec.id, spec=spec)
+
+    iterator = loader.load()
+    assert next(iterator) == 1
+
+    iterator.close()
+
+    assert upstream.closed == 1

--- a/tests/unit/transforms/test_vector_ensure_schema.py
+++ b/tests/unit/transforms/test_vector_ensure_schema.py
@@ -164,3 +164,18 @@ def test_vector_ensure_schema_raises_without_schema_artifact():
 
     with pytest.raises(RuntimeError):
         list(transform.apply(stream))
+
+
+def test_vector_ensure_schema_uses_schema_snapshot_captured_at_bind_time():
+    stream = iter([make_vector(0, {"wind__B": 5.0, "wind__A": 2.0})])
+    context = StubVectorContext(
+        [],
+        schema={"features": [{"id": "wind__A"}, {"id": "wind__B"}]},
+    )
+    transform = VectorEnsureSchemaTransform()
+    transform.bind_context(context)
+
+    context._schema_map["features"] = []
+
+    out = list(transform.apply(stream))
+    assert out[0].features.values == {"wind__A": 2.0, "wind__B": 5.0}


### PR DESCRIPTION
## Summary
- add an ephemeral record-stream cache that reuses contract outputs within a run/request
- add profile and CLI controls for enabling or disabling cache usage
- clean up composed source observability and cache-backed source messages in the CLI visuals

## Testing
- ./.venv/bin/pytest tests/unit/cli tests/unit/profiles tests/unit/pipeline tests/unit/services
