### PR TITLE
Improve execution progress and vector key planning

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -10,8 +10,9 @@ that profile explicitly, including one configured with `enabled: false`.
 With `--visuals on` in an interactive terminal, runtime commands show one live
 pipeline row with the active node. `--log-level DEBUG` expands that view to one row
 per active node. File-backed sources include the current file and position
-(`2/17`); bars remain indeterminate when the record total is not known without
-reading the data. Visuals are independent of log filtering.
+(`2/17`). Determinate bars appear only when the item total is known; otherwise
+the timer and current activity remain visible. Visuals are independent of log
+filtering.
 
 ### Preview Stages
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "jerry-thomas"
-version = "5.0.4"
+version = "5.0.5"
 description = "Jerry-Thomas: a stream-first, plugin-friendly data pipeline (mixology-themed CLI)"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "jerry-thomas"
-version = "5.0.3"
+version = "5.0.4"
 description = "Jerry-Thomas: a stream-first, plugin-friendly data pipeline (mixology-themed CLI)"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/datapipeline/cli/logging_setup.py
+++ b/src/datapipeline/cli/logging_setup.py
@@ -1,6 +1,7 @@
 import logging
 import sys
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Iterator, Sequence
+from contextlib import contextmanager
 from pathlib import Path
 
 from datapipeline.cli.visuals.execution import ExecutionMessage
@@ -129,3 +130,33 @@ def configure_root_logging(level: int, output: LogOutputSettings) -> None:
         handlers=handlers,
         force=True,
     )
+
+
+@contextmanager
+def root_logging_scope(
+    level: int,
+    output: LogOutputSettings,
+) -> Iterator[None]:
+    """Temporarily replace root logging without closing the outer handlers."""
+
+    root = logging.getLogger()
+    previous_level = root.level
+    previous_handlers = tuple(root.handlers)
+    for handler in previous_handlers:
+        root.removeHandler(handler)
+
+    try:
+        configure_root_logging(level, output)
+        yield
+    finally:
+        temporary_handlers = tuple(root.handlers)
+        for handler in temporary_handlers:
+            root.removeHandler(handler)
+
+        try:
+            for handler in temporary_handlers:
+                handler.close()
+        finally:
+            root.setLevel(previous_level)
+            for handler in previous_handlers:
+                root.addHandler(handler)

--- a/src/datapipeline/cli/visuals/execution.py
+++ b/src/datapipeline/cli/visuals/execution.py
@@ -120,7 +120,8 @@ class ExecutionEventFormatter:
         if isinstance(event, OperationProgress):
             return (
                 f"Operation {event.name} · {event.step} · running "
-                f"elapsed={event.step_elapsed_seconds:.0f}s items={event.items}"
+                f"elapsed={event.step_elapsed_seconds:.0f}s "
+                f"{event.unit}={event.completed}"
             )
         if isinstance(event, NodeFinished):
             error_suffix = cls.error_suffix(event)

--- a/src/datapipeline/cli/visuals/execution.py
+++ b/src/datapipeline/cli/visuals/execution.py
@@ -18,6 +18,7 @@ from datapipeline.execution.events import (
 )
 from datapipeline.execution.observer import PipelineObserver
 from datapipeline.execution.observability import (
+    CommandFinished,
     FileResult,
     OperationFinished,
     OperationProgress,
@@ -33,6 +34,7 @@ class ExecutionMessage:
 
 ExecutionLogEvent = (
     ExecutionMessage
+    | CommandFinished
     | FileResult
     | PipelineEvent
     | OperationStarted
@@ -62,12 +64,16 @@ class ExecutionEventFormatter:
     def level(event: ExecutionLogEvent) -> int:
         if isinstance(event, ExecutionMessage):
             return int(event.log_level)
-        if isinstance(event, PipelineFinished | NodeFinished | OperationFinished):
+        if isinstance(
+            event,
+            CommandFinished | PipelineFinished | NodeFinished | OperationFinished,
+        ):
             if event.status == "error":
                 return logging.ERROR
         if isinstance(
             event,
-            FileResult
+            CommandFinished
+            | FileResult
             | PipelineStarted
             | PipelineSummary
             | PipelineProgress
@@ -85,6 +91,11 @@ class ExecutionEventFormatter:
     def message(cls, event: ExecutionLogEvent) -> str:
         if isinstance(event, FileResult):
             return f"{event.label}: {event.path}"
+        if isinstance(event, CommandFinished):
+            return (
+                f"Command {event.command} finished status={event.status} "
+                f"elapsed={event.elapsed_seconds:.6f}s"
+            )
         if isinstance(event, OperationStarted):
             return f"Operation {event.name} started"
         if isinstance(event, OperationFinished):

--- a/src/datapipeline/cli/visuals/rich/progress.py
+++ b/src/datapipeline/cli/visuals/rich/progress.py
@@ -62,7 +62,7 @@ class _ProgressActivityColumn(ProgressColumn):
 
     def render(self, task: Task) -> RenderableType:
         status = Text(task.fields["status"])
-        if not task.fields["show_bar"]:
+        if task.total is None:
             return status
         activity = Table.grid(padding=(0, 1))
         activity.add_row(self._bar.render(task), status)
@@ -117,7 +117,6 @@ class _ExecutionProgress:
             f"Operation {event.name}",
             total=None,
             status="",
-            show_bar=False,
         )
 
     def _update_operation(self, event: OperationProgress) -> None:
@@ -146,7 +145,6 @@ class _ExecutionProgress:
             f"[{event.pipeline_name}]",
             total=None,
             status="",
-            show_bar=False,
         )
 
     def _finish_pipeline(self, event: PipelineFinished) -> None:
@@ -165,7 +163,6 @@ class _ExecutionProgress:
             label,
             total=None,
             status="0 out",
-            show_bar=True,
             visible=self._debug,
         )
         self._open_nodes.append(event.node_index)

--- a/src/datapipeline/cli/visuals/rich/progress.py
+++ b/src/datapipeline/cli/visuals/rich/progress.py
@@ -127,8 +127,8 @@ class _ExecutionProgress:
             raise RuntimeError("Operation progress updated out of order")
         self._progress.update(
             self._operation_task,
-            completed=event.items,
-            status=f"{event.step} · {event.items:,} items",
+            completed=event.completed,
+            status=f"{event.step} · {event.completed:,} {event.unit}",
         )
 
     def _finish_operation(self, event: OperationFinished) -> None:

--- a/src/datapipeline/cli/visuals/rich/progress.py
+++ b/src/datapipeline/cli/visuals/rich/progress.py
@@ -35,6 +35,7 @@ from datapipeline.execution.events import (
     ProgressSnapshot,
 )
 from datapipeline.execution.observability import (
+    CommandFinished,
     FileResult,
     OperationFinished,
     OperationProgress,
@@ -305,7 +306,10 @@ class _RichExecutionRenderer:
     def _render_event(self, event: ExecutionLogEvent) -> Text:
         level = ExecutionEventFormatter.level(event)
         text = Text(ExecutionEventFormatter.message(event))
-        if isinstance(event, PipelineFinished | NodeFinished | OperationFinished):
+        if isinstance(
+            event,
+            CommandFinished | PipelineFinished | NodeFinished | OperationFinished,
+        ):
             status_style = "green" if event.status == "success" else "red"
             text.highlight_words([f"status={event.status}"], style=status_style)
         elif level >= logging.ERROR:

--- a/src/datapipeline/cli/visuals/rich/progress.py
+++ b/src/datapipeline/cli/visuals/rich/progress.py
@@ -11,6 +11,7 @@ from rich.progress import (
     Task,
     TaskID,
 )
+from rich.rule import Rule
 from rich.table import Column, Table
 from rich.text import Text
 
@@ -114,7 +115,7 @@ class _ExecutionProgress:
             raise RuntimeError("Cannot start overlapping operation progress")
         self._operation_name = event.name
         self._operation_task = self._progress.add_task(
-            f"Operation {event.name}",
+            "Elapsed",
             total=None,
             status="",
         )
@@ -272,9 +273,12 @@ class _RichExecutionRenderer:
             | PipelineFinished,
         ):
             self._progress.handle(event)
+            if isinstance(event, OperationStarted):
+                self._console.print(Rule(Text(f"Operation {event.name}"), style="dim"))
+                return
             if isinstance(
                 event,
-                OperationStarted | OperationProgress | NodeStarted | NodeProgress,
+                OperationProgress | NodeStarted | NodeProgress,
             ):
                 return
         if isinstance(event, NodeProgress):

--- a/src/datapipeline/execution/observability.py
+++ b/src/datapipeline/execution/observability.py
@@ -5,6 +5,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal, Protocol
 
+from datapipeline.execution.events import RunStatus
+
 
 OperationStatus = Literal["success", "error"]
 
@@ -30,6 +32,13 @@ class OperationFinished:
     elapsed_seconds: float
     error_type: str | None = None
     error_message: str | None = None
+
+
+@dataclass(frozen=True)
+class CommandFinished:
+    command: str
+    status: RunStatus
+    elapsed_seconds: float
 
 
 @dataclass(frozen=True)

--- a/src/datapipeline/execution/observability.py
+++ b/src/datapipeline/execution/observability.py
@@ -19,7 +19,8 @@ class OperationProgress:
     name: str
     step: str
     step_elapsed_seconds: float
-    items: int
+    completed: int
+    unit: str
 
 
 @dataclass(frozen=True)
@@ -118,7 +119,8 @@ def emit_file_result(
 def emit_operation_progress(
     step: str,
     step_elapsed_seconds: float,
-    items: int,
+    completed: int,
+    unit: str,
 ) -> bool:
     name = _CURRENT_OPERATION_NAME.get()
     observer = current_operation_observer()
@@ -129,25 +131,27 @@ def emit_operation_progress(
             name=name,
             step=step,
             step_elapsed_seconds=step_elapsed_seconds,
-            items=items,
+            completed=completed,
+            unit=unit,
         )
     )
     return True
 
 
 class OperationProgressTracker:
-    def __init__(self, step: str, interval_seconds: float) -> None:
+    def __init__(self, step: str, unit: str, interval_seconds: float) -> None:
         interval = float(interval_seconds)
         if interval < 0:
             raise ValueError("interval_seconds must be non-negative")
         self._step = step
+        self._unit = unit
         self._interval_seconds = interval
         self._started_at = time.perf_counter()
         self._last_emit_at = self._started_at
-        self._items = 0
+        self._completed = 0
 
-    def advance(self, items: int = 1) -> None:
-        self._items += int(items)
+    def advance(self, count: int = 1) -> None:
+        self._completed += int(count)
         if self._interval_seconds <= 0:
             return
         now = time.perf_counter()
@@ -155,4 +159,4 @@ class OperationProgressTracker:
             return
         self._last_emit_at = now
         elapsed = now - self._started_at
-        emit_operation_progress(self._step, elapsed, self._items)
+        emit_operation_progress(self._step, elapsed, self._completed, self._unit)

--- a/src/datapipeline/operations/artifacts/metadata.py
+++ b/src/datapipeline/operations/artifacts/metadata.py
@@ -12,12 +12,11 @@ from datapipeline.artifacts.models import (
     Window,
     WindowMode,
 )
-from datapipeline.utils.time import floor_time_to_cadence
 from datapipeline.config.tasks import MetadataTask
 from datapipeline.operations.persistence import ArtifactOutput
 from datapipeline.runtime import Runtime
 from datapipeline.utils.json_artifact import write_json_artifact
-from datapipeline.utils.time import parse_cadence
+from datapipeline.utils.time import count_cadence_buckets, parse_cadence
 
 from .utils import (
     collect_vector_metadata,
@@ -107,17 +106,6 @@ def _window_bounds_from_stats(
     if mode == "relaxed":
         return _range_union(partition_ranges)
     raise ValueError(f"Unsupported metadata window mode {mode!r}.")
-
-
-def _window_size(
-    start: datetime,
-    end: datetime,
-    cadence: str,
-) -> int:
-    step = parse_cadence(cadence)
-    anchored_start = floor_time_to_cadence(start, step)
-    anchored_end = floor_time_to_cadence(end, step)
-    return int(((anchored_end - anchored_start) / step)) + 1
 
 
 def _merge_sample_domains(
@@ -227,7 +215,7 @@ def materialize_metadata(
     start = computed_start
     end = computed_end
     if start is not None and end is not None:
-        size = _window_size(start, end, dataset.sample.cadence)
+        size = count_cadence_buckets(start, end, parse_cadence(dataset.sample.cadence))
         window_obj = Window(start=start, end=end, mode=task_cfg.window_mode, size=size)
     sample_domain = _merge_sample_domains(
         feature_domain,

--- a/src/datapipeline/operations/artifacts/ticks.py
+++ b/src/datapipeline/operations/artifacts/ticks.py
@@ -75,6 +75,7 @@ def materialize_ticks(
     stream = run_stream_pipeline(context, task_cfg.stream)
     project_progress = OperationProgressTracker(
         "project_ticks",
+        "records",
         heartbeat_interval,
     )
     tick_rows = _project_tick_rows(stream, task_cfg.grid_by, project_progress)
@@ -92,6 +93,7 @@ def materialize_ticks(
         destination = (runtime.artifacts_root / relative_path).resolve()
         write_progress = OperationProgressTracker(
             "write_artifact",
+            "rows",
             heartbeat_interval,
         )
         sink = AtomicTextFileSink(destination)

--- a/src/datapipeline/operations/artifacts/utils.py
+++ b/src/datapipeline/operations/artifacts/utils.py
@@ -119,6 +119,7 @@ def collect_vector_metadata(
     vector_count = 0
     progress = OperationProgressTracker(
         progress_step,
+        "vectors",
         resolve_heartbeat_interval_seconds(runtime.heartbeat_interval_seconds),
     )
     try:

--- a/src/datapipeline/operations/persistence.py
+++ b/src/datapipeline/operations/persistence.py
@@ -148,6 +148,7 @@ def _persist_runtime_output(
     writer = writer_factory(effective_target)
     progress = OperationProgressTracker(
         "write_output",
+        "rows",
         resolve_heartbeat_interval_seconds(heartbeat_interval_seconds),
     )
     success = False
@@ -201,6 +202,7 @@ def _persist_routed_runtime_output(
     rows = iter(result.rows)
     progress = OperationProgressTracker(
         "write_output",
+        "rows",
         resolve_heartbeat_interval_seconds(heartbeat_interval_seconds),
     )
     success = False

--- a/src/datapipeline/pipelines/dataset/pipeline.py
+++ b/src/datapipeline/pipelines/dataset/pipeline.py
@@ -10,7 +10,6 @@ from datapipeline.artifacts.specs import dataset_requires_scaler
 from datapipeline.config.dataset.split import DatasetFold
 from datapipeline.config.dataset.feature import FeatureRecordConfig
 from datapipeline.execution.context import PipelineContext
-from datapipeline.execution.events import ProgressSnapshot
 from datapipeline.execution.node import PipelineNode, SourceNode
 from datapipeline.execution.pipeline import Pipeline
 from datapipeline.execution.runner import run_pipeline
@@ -19,10 +18,7 @@ from datapipeline.pipelines.dataset.nodes import (
     select_fold_samples,
 )
 from datapipeline.pipelines.dataset.split import build_labeler
-from datapipeline.pipelines.vector.pipeline import (
-    build_vector_pipeline,
-    rectangular_key_plan,
-)
+from datapipeline.pipelines.vector.pipeline import build_vector_source_node
 from datapipeline.domain.sample import Sample
 from datapipeline.transforms.vector.scaler import SampleScaler
 
@@ -60,7 +56,7 @@ def build_dataset_pipeline(
     return Pipeline(
         name="dataset",
         nodes=(
-            _vector_source(
+            build_vector_source_node(
                 context,
                 feature_configs,
                 group_by_cadence,
@@ -93,7 +89,7 @@ def run_scaled_dataset_pipeline(
         Pipeline(
             name="dataset",
             nodes=(
-                _vector_source(
+                build_vector_source_node(
                     context,
                     feature_configs,
                     group_by_cadence,
@@ -133,7 +129,7 @@ def run_fold_dataset_pipeline(
         )
 
     nodes: list[PipelineNode | SourceNode] = [
-        _vector_source(
+        build_vector_source_node(
             context,
             feature_configs,
             group_by_cadence,
@@ -180,36 +176,4 @@ def _sample_scaler(
             for config in (() if target_configs is None else target_configs)
             if config.scale
         ),
-    )
-
-
-def _vector_source(
-    context: PipelineContext,
-    feature_configs: Sequence[FeatureRecordConfig],
-    group_by_cadence: str,
-    target_configs: Sequence[FeatureRecordConfig] | None,
-    rectangular: bool,
-    sample_keys: Sequence[str],
-) -> SourceNode:
-    progress = None
-    if rectangular and (feature_configs or target_configs):
-        key_plan = rectangular_key_plan(context, group_by_cadence, sample_keys)
-        if key_plan is not None:
-            progress = partial(
-                ProgressSnapshot,
-                total=key_plan.total,
-                unit="samples",
-            )
-    return SourceNode(
-        name="vector_assemble",
-        open=partial(
-            build_vector_pipeline,
-            context,
-            feature_configs,
-            group_by_cadence,
-            target_configs,
-            rectangular,
-            sample_keys,
-        ),
-        progress=progress,
     )

--- a/src/datapipeline/pipelines/dataset/pipeline.py
+++ b/src/datapipeline/pipelines/dataset/pipeline.py
@@ -10,6 +10,7 @@ from datapipeline.artifacts.specs import dataset_requires_scaler
 from datapipeline.config.dataset.split import DatasetFold
 from datapipeline.config.dataset.feature import FeatureRecordConfig
 from datapipeline.execution.context import PipelineContext
+from datapipeline.execution.events import ProgressSnapshot
 from datapipeline.execution.node import PipelineNode, SourceNode
 from datapipeline.execution.pipeline import Pipeline
 from datapipeline.execution.runner import run_pipeline
@@ -18,7 +19,10 @@ from datapipeline.pipelines.dataset.nodes import (
     select_fold_samples,
 )
 from datapipeline.pipelines.dataset.split import build_labeler
-from datapipeline.pipelines.vector.pipeline import build_vector_pipeline
+from datapipeline.pipelines.vector.pipeline import (
+    build_vector_pipeline,
+    rectangular_key_plan,
+)
 from datapipeline.domain.sample import Sample
 from datapipeline.transforms.vector.scaler import SampleScaler
 
@@ -187,6 +191,15 @@ def _vector_source(
     rectangular: bool,
     sample_keys: Sequence[str],
 ) -> SourceNode:
+    progress = None
+    if rectangular and (feature_configs or target_configs):
+        key_plan = rectangular_key_plan(context, group_by_cadence, sample_keys)
+        if key_plan is not None:
+            progress = partial(
+                ProgressSnapshot,
+                total=key_plan.total,
+                unit="samples",
+            )
     return SourceNode(
         name="vector_assemble",
         open=partial(
@@ -198,4 +211,5 @@ def _vector_source(
             rectangular,
             sample_keys,
         ),
+        progress=progress,
     )

--- a/src/datapipeline/pipelines/vector/keygen.py
+++ b/src/datapipeline/pipelines/vector/keygen.py
@@ -1,7 +1,69 @@
-from datetime import timedelta
+from collections.abc import Iterator, Sequence
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any
 
+from datapipeline.artifacts.models import SampleDomainEntry
 from datapipeline.domain.feature import FeatureRecord, FeatureSequence
-from datapipeline.utils.time import floor_time_to_cadence
+from datapipeline.utils.time import (
+    floor_time_to_cadence,
+    parse_cadence,
+)
+
+
+_SampleWindow = tuple[tuple[Any, ...], datetime, datetime]
+
+
+@dataclass(frozen=True)
+class RectangularKeyPlan:
+    start: datetime
+    end: datetime
+    step: timedelta
+    windows: tuple[_SampleWindow, ...]
+
+    @property
+    def total(self) -> int | None:
+        if not self.windows:
+            return 0
+        if not self._has_consistent_time_lattice():
+            return None
+
+        last_plan_index = (self.end - self.start) // self.step
+        total = 0
+        for _, window_start, window_end in self.windows:
+            first_index, remainder = divmod(window_start - self.start, self.step)
+            if remainder:
+                first_index += 1
+            first_index = max(0, first_index)
+            last_index = min(
+                last_plan_index,
+                (window_end - self.start) // self.step,
+            )
+            total += max(0, last_index - first_index + 1)
+        return total
+
+    def keys(self) -> Iterator[tuple]:
+        current = self.start
+        while current <= self.end:
+            for key_values, window_start, window_end in self.windows:
+                if window_start <= current <= window_end:
+                    yield (current, *key_values)
+            current += self.step
+
+    def _has_consistent_time_lattice(self) -> bool:
+        origin_timezone = self.start.tzinfo
+        # Fixed-offset origins advance in absolute time. Dynamic zones advance in
+        # wall time, so their bounds must share the origin's timezone object.
+        if isinstance(origin_timezone, timezone):
+            return self.end.tzinfo is not None and all(
+                window_start.tzinfo is not None and window_end.tzinfo is not None
+                for _, window_start, window_end in self.windows
+            )
+        return self.end.tzinfo is origin_timezone and all(
+            window_start.tzinfo is origin_timezone
+            and window_end.tzinfo is origin_timezone
+            for _, window_start, window_end in self.windows
+        )
 
 
 def group_key_for(
@@ -9,3 +71,59 @@ def group_key_for(
     cadence: timedelta,
 ) -> tuple:
     return (floor_time_to_cadence(item.time, cadence), *item.entity_key)
+
+
+def window_key_plan(
+    start: datetime | None,
+    end: datetime | None,
+    cadence: str | None,
+) -> RectangularKeyPlan | None:
+    if start is None or end is None or cadence is None:
+        return None
+    step = parse_cadence(cadence)
+    window_start = floor_time_to_cadence(start, step)
+    window_end = floor_time_to_cadence(end, step)
+    return RectangularKeyPlan(
+        start=window_start,
+        end=window_end,
+        step=step,
+        windows=(((), window_start, window_end),),
+    )
+
+
+def sample_domain_key_plan(
+    start: datetime | None,
+    end: datetime | None,
+    cadence: str,
+    sample_keys: Sequence[str],
+    domain: Sequence[SampleDomainEntry],
+) -> RectangularKeyPlan | None:
+    plan = window_key_plan(start, end, cadence)
+    if plan is None:
+        return None
+    if not sample_keys:
+        return plan
+
+    prepared: list[_SampleWindow] = []
+    for entry in domain:
+        if len(entry.key) != len(sample_keys):
+            raise ValueError(
+                "Vector metadata sample-domain key length does not match sample.keys."
+            )
+        domain_start = max(
+            plan.start,
+            floor_time_to_cadence(entry.start, plan.step),
+        )
+        domain_end = min(
+            plan.end,
+            floor_time_to_cadence(entry.end, plan.step),
+        )
+        if domain_start <= domain_end:
+            prepared.append((tuple(entry.key), domain_start, domain_end))
+    prepared.sort(key=lambda item: item[0])
+    return RectangularKeyPlan(
+        start=plan.start,
+        end=plan.end,
+        step=plan.step,
+        windows=tuple(prepared),
+    )

--- a/src/datapipeline/pipelines/vector/nodes.py
+++ b/src/datapipeline/pipelines/vector/nodes.py
@@ -1,13 +1,10 @@
-from collections.abc import Iterator, Sequence
-from datetime import datetime
+from collections.abc import Iterator
 from itertools import groupby
 from typing import Any
 
-from datapipeline.artifacts.models import SampleDomainEntry
 from datapipeline.domain.feature import FeatureRecord, FeatureSequence
 from datapipeline.domain.sample import Sample
 from datapipeline.domain.vector import Vector
-from datapipeline.utils.time import floor_time_to_cadence, parse_cadence
 
 
 def _close_iterator(iterator) -> None:
@@ -44,66 +41,6 @@ def vector_assemble_stage(
             yield group_key, Vector(values=values)
     finally:
         _close_iterator(merged)
-
-
-def window_keys(
-    start: datetime | None,
-    end: datetime | None,
-    cadence: str | None,
-) -> Iterator[tuple] | None:
-    if start is None or end is None or cadence is None:
-        return None
-    step = parse_cadence(cadence)
-    current = floor_time_to_cadence(start, step)
-    stop = floor_time_to_cadence(end, step)
-    if stop < current:
-        return None
-
-    def _iter():
-        t = current
-        while t <= stop:
-            yield (t,)
-            t = t + step
-
-    return _iter()
-
-
-def sample_domain_window_keys(
-    start: datetime | None,
-    end: datetime | None,
-    cadence: str,
-    sample_keys: Sequence[str],
-    domain: Sequence[SampleDomainEntry],
-) -> Iterator[tuple] | None:
-    if start is None or end is None:
-        return None
-    if not sample_keys:
-        return window_keys(start, end, cadence)
-    step = parse_cadence(cadence)
-    global_start = floor_time_to_cadence(start, step)
-    global_end = floor_time_to_cadence(end, step)
-
-    prepared = []
-    for entry in domain:
-        if len(entry.key) != len(sample_keys):
-            raise ValueError(
-                "Vector metadata sample-domain key length does not match sample.keys."
-            )
-        domain_start = max(global_start, floor_time_to_cadence(entry.start, step))
-        domain_end = min(global_end, floor_time_to_cadence(entry.end, step))
-        if domain_start <= domain_end:
-            prepared.append((tuple(entry.key), domain_start, domain_end))
-    prepared.sort(key=lambda item: item[0])
-
-    def _iter():
-        current = global_start
-        while current <= global_end:
-            for key_values, domain_start, domain_end in prepared:
-                if domain_start <= current <= domain_end:
-                    yield (current, *key_values)
-            current = current + step
-
-    return _iter()
 
 
 def align_stream(

--- a/src/datapipeline/pipelines/vector/pipeline.py
+++ b/src/datapipeline/pipelines/vector/pipeline.py
@@ -2,6 +2,7 @@ import heapq
 from collections.abc import Iterator, Sequence
 from contextlib import ExitStack
 from datetime import timedelta
+from functools import partial
 from itertools import tee
 from pathlib import Path
 
@@ -16,6 +17,8 @@ from datapipeline.domain.feature import FeatureRecord, FeatureSequence
 from datapipeline.domain.sample import Sample
 from datapipeline.domain.sample_key import SampleKeyContract
 from datapipeline.execution.context import PipelineContext
+from datapipeline.execution.events import ProgressSnapshot
+from datapipeline.execution.node import SourceNode
 from datapipeline.pipelines.vector.keygen import (
     RectangularKeyPlan,
     group_key_for,
@@ -30,6 +33,7 @@ from datapipeline.pipelines.vector.nodes import (
 from datapipeline.utils.time import parse_cadence
 from datapipeline.vector_inputs.store import (
     CachedVectorInputShard,
+    CachedVectorInputsManifest,
     load_vector_inputs_manifest,
     open_vector_input_records,
 )
@@ -43,10 +47,101 @@ def build_vector_pipeline(
     rectangular: bool = True,
     sample_keys: Sequence[str] = (),
 ) -> Iterator[Sample]:
-    feature_cfgs = configs
-    target_cfgs = () if target_configs is None else target_configs
+    feature_cfgs = tuple(configs)
+    target_cfgs = tuple(() if target_configs is None else target_configs)
+    sample_key_fields = tuple(sample_keys)
     if not feature_cfgs and not target_cfgs:
         return iter(())
+
+    manifest_path, manifest, sample_key_contract = _require_vector_inputs(
+        context, group_by_cadence, sample_key_fields
+    )
+    cadence = parse_cadence(group_by_cadence)
+    key_plan = (
+        rectangular_key_plan(context, group_by_cadence, sample_key_fields)
+        if rectangular
+        else None
+    )
+    return _assemble_vector_samples(
+        manifest_path=manifest_path,
+        manifest=manifest,
+        feature_configs=feature_cfgs,
+        target_configs=target_cfgs,
+        cadence=cadence,
+        sample_key_contract=sample_key_contract,
+        key_plan=key_plan,
+    )
+
+
+def build_vector_source_node(
+    context: PipelineContext,
+    configs: Sequence[FeatureRecordConfig],
+    group_by_cadence: str,
+    target_configs: Sequence[FeatureRecordConfig] | None = None,
+    rectangular: bool = True,
+    sample_keys: Sequence[str] = (),
+) -> SourceNode:
+    feature_cfgs = tuple(configs)
+    target_cfgs = tuple(() if target_configs is None else target_configs)
+    sample_key_fields = tuple(sample_keys)
+    has_inputs = bool(feature_cfgs or target_cfgs)
+    key_plan = (
+        rectangular_key_plan(context, group_by_cadence, sample_key_fields)
+        if rectangular and has_inputs
+        else None
+    )
+    progress = None
+    if key_plan is not None:
+        progress = partial(
+            ProgressSnapshot,
+            total=key_plan.total,
+            unit="samples",
+        )
+    return SourceNode(
+        name="vector_assemble",
+        open=partial(
+            _open_vector_samples,
+            context,
+            feature_cfgs,
+            group_by_cadence,
+            target_cfgs,
+            sample_key_fields,
+            key_plan,
+        ),
+        progress=progress,
+    )
+
+
+def _open_vector_samples(
+    context: PipelineContext,
+    feature_configs: Sequence[FeatureRecordConfig],
+    group_by_cadence: str,
+    target_configs: Sequence[FeatureRecordConfig],
+    sample_keys: Sequence[str],
+    key_plan: RectangularKeyPlan | None,
+) -> Iterator[Sample]:
+    if not feature_configs and not target_configs:
+        return iter(())
+
+    manifest_path, manifest, sample_key_contract = _require_vector_inputs(
+        context, group_by_cadence, sample_keys
+    )
+    return _assemble_vector_samples(
+        manifest_path=manifest_path,
+        manifest=manifest,
+        feature_configs=feature_configs,
+        target_configs=target_configs,
+        cadence=parse_cadence(group_by_cadence),
+        sample_key_contract=sample_key_contract,
+        key_plan=key_plan,
+    )
+
+
+def _require_vector_inputs(
+    context: PipelineContext,
+    group_by_cadence: str,
+    sample_keys: Sequence[str],
+) -> tuple[Path, CachedVectorInputsManifest, SampleKeyContract]:
     artifact = context.runtime.artifacts.optional(VECTOR_INPUTS)
     if artifact is None:
         raise RuntimeError(
@@ -70,16 +165,21 @@ def build_vector_pipeline(
         sample_keys,
         manifest.sample_key_types,
     )
+    return manifest_path, manifest, sample_key_contract
 
-    cadence = parse_cadence(group_by_cadence)
-    key_plan = (
-        rectangular_key_plan(context, group_by_cadence, sample_keys)
-        if rectangular
-        else None
-    )
+
+def _assemble_vector_samples(
+    manifest_path: Path,
+    manifest: CachedVectorInputsManifest,
+    feature_configs: Sequence[FeatureRecordConfig],
+    target_configs: Sequence[FeatureRecordConfig],
+    cadence: timedelta,
+    sample_key_contract: SampleKeyContract,
+    key_plan: RectangularKeyPlan | None,
+) -> Iterator[Sample]:
     feature_keys = None if key_plan is None else key_plan.keys()
     target_keys = None
-    if feature_keys is not None and target_cfgs:
+    if feature_keys is not None and target_configs:
         feature_keys, target_keys = tee(feature_keys)
 
     keyed_feature_records = _merged_keyed_records(
@@ -87,9 +187,9 @@ def build_vector_pipeline(
         shards=_shards_for_configs(
             manifest.features,
             manifest.targets,
-            feature_cfgs,
+            feature_configs,
         ),
-        configs=feature_cfgs,
+        configs=feature_configs,
         group_by_cadence=cadence,
         sample_key_contract=sample_key_contract,
     )
@@ -97,11 +197,11 @@ def build_vector_pipeline(
     aligned_feature_vectors = align_stream(feature_vectors, feature_keys)
 
     target_vectors = None
-    if target_cfgs:
+    if target_configs:
         keyed_target_records = _merged_keyed_records(
             manifest_path=manifest_path,
             shards=manifest.targets,
-            configs=target_cfgs,
+            configs=target_configs,
             group_by_cadence=cadence,
             sample_key_contract=sample_key_contract,
         )

--- a/src/datapipeline/pipelines/vector/pipeline.py
+++ b/src/datapipeline/pipelines/vector/pipeline.py
@@ -16,13 +16,16 @@ from datapipeline.domain.feature import FeatureRecord, FeatureSequence
 from datapipeline.domain.sample import Sample
 from datapipeline.domain.sample_key import SampleKeyContract
 from datapipeline.execution.context import PipelineContext
-from datapipeline.pipelines.vector.keygen import group_key_for
+from datapipeline.pipelines.vector.keygen import (
+    RectangularKeyPlan,
+    group_key_for,
+    sample_domain_key_plan,
+    window_key_plan,
+)
 from datapipeline.pipelines.vector.nodes import (
     align_stream,
     sample_assemble_stage,
-    sample_domain_window_keys,
     vector_assemble_stage,
-    window_keys,
 )
 from datapipeline.utils.time import parse_cadence
 from datapipeline.vector_inputs.store import (
@@ -69,22 +72,15 @@ def build_vector_pipeline(
     )
 
     cadence = parse_cadence(group_by_cadence)
-    keys_feature = None
-    keys_target = None
-    if rectangular:
-        start, end = context.window_bounds(rectangular_required=True)
-        keys = _rectangular_keys(
-            context,
-            start,
-            end,
-            group_by_cadence,
-            sample_keys,
-        )
-        if keys is not None:
-            if target_cfgs:
-                keys_feature, keys_target = tee(keys, 2)
-            else:
-                keys_feature = keys
+    key_plan = (
+        rectangular_key_plan(context, group_by_cadence, sample_keys)
+        if rectangular
+        else None
+    )
+    feature_keys = None if key_plan is None else key_plan.keys()
+    target_keys = None
+    if feature_keys is not None and target_cfgs:
+        feature_keys, target_keys = tee(feature_keys)
 
     keyed_feature_records = _merged_keyed_records(
         manifest_path=manifest_path,
@@ -98,7 +94,7 @@ def build_vector_pipeline(
         sample_key_contract=sample_key_contract,
     )
     feature_vectors = vector_assemble_stage(keyed_feature_records)
-    aligned_feature_vectors = align_stream(feature_vectors, keys_feature)
+    aligned_feature_vectors = align_stream(feature_vectors, feature_keys)
 
     target_vectors = None
     if target_cfgs:
@@ -111,7 +107,7 @@ def build_vector_pipeline(
         )
         target_vectors = align_stream(
             vector_assemble_stage(keyed_target_records),
-            keys_target,
+            target_keys,
         )
     return sample_assemble_stage(aligned_feature_vectors, target_vectors)
 
@@ -175,17 +171,16 @@ def _merged_keyed_records(
         yield from merged_stream
 
 
-def _rectangular_keys(
+def rectangular_key_plan(
     context: PipelineContext,
-    start,
-    end,
     cadence: str,
     sample_keys: Sequence[str],
-) -> Iterator[tuple] | None:
+) -> RectangularKeyPlan | None:
+    start, end = context.window_bounds(rectangular_required=True)
     if not sample_keys:
-        return window_keys(start, end, cadence)
+        return window_key_plan(start, end, cadence)
     domain = _sample_domain(context, cadence, sample_keys)
-    return sample_domain_window_keys(start, end, cadence, sample_keys, domain)
+    return sample_domain_key_plan(start, end, cadence, sample_keys, domain)
 
 
 def _sample_domain(

--- a/src/datapipeline/profiles/executor.py
+++ b/src/datapipeline/profiles/executor.py
@@ -3,7 +3,7 @@ from contextlib import AbstractContextManager, nullcontext
 from dataclasses import dataclass
 from typing import Any, Callable
 
-from datapipeline.cli.logging_setup import configure_root_logging
+from datapipeline.cli.logging_setup import root_logging_scope
 from datapipeline.cli.visuals.execution import (
     make_operation_observer,
     make_pipeline_observer,
@@ -25,35 +25,31 @@ class ExecutionSpec:
 
 def run_execution(spec: ExecutionSpec, work: Callable[[], Any]) -> Any:
     level = spec.observability.log_decision.value
-    configure_root_logging(
-        level=level,
-        output=spec.observability.log_output,
-    )
+    with root_logging_scope(level, spec.observability.log_output):
+        visuals_active = spec.observability.visuals == "on" and rich_visuals_supported()
+        visuals: AbstractContextManager[Any]
+        if visuals_active:
+            visuals = visual_execution(level)
+        else:
+            visuals = nullcontext()
 
-    visuals_active = spec.observability.visuals == "on" and rich_visuals_supported()
-    visuals: AbstractContextManager[Any]
-    if visuals_active:
-        visuals = visual_execution(level)
-    else:
-        visuals = nullcontext()
-
-    runtime = spec.runtime
-    previous_pipeline_observer = runtime.pipeline_observer
-    previous_observe_node_events = runtime.observe_node_events
-    if previous_pipeline_observer is None:
-        runtime.pipeline_observer = make_pipeline_observer(
-            logging.getLogger("datapipeline.execution.observer")
-        )
-        runtime.observe_node_events = visuals_active or level <= logging.DEBUG
-
-    try:
-        observer = make_operation_observer(
-            logging.getLogger("datapipeline.operation.observer")
-        )
-        with operation_observer(observer):
-            with visuals:
-                return work()
-    finally:
+        runtime = spec.runtime
+        previous_pipeline_observer = runtime.pipeline_observer
+        previous_observe_node_events = runtime.observe_node_events
         if previous_pipeline_observer is None:
-            runtime.pipeline_observer = None
-            runtime.observe_node_events = previous_observe_node_events
+            runtime.pipeline_observer = make_pipeline_observer(
+                logging.getLogger("datapipeline.execution.observer")
+            )
+            runtime.observe_node_events = visuals_active or level <= logging.DEBUG
+
+        try:
+            observer = make_operation_observer(
+                logging.getLogger("datapipeline.operation.observer")
+            )
+            with operation_observer(observer):
+                with visuals:
+                    return work()
+        finally:
+            if previous_pipeline_observer is None:
+                runtime.pipeline_observer = None
+                runtime.observe_node_events = previous_observe_node_events

--- a/src/datapipeline/profiles/models.py
+++ b/src/datapipeline/profiles/models.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal, Sequence
 
@@ -54,6 +54,7 @@ class BuildRunRequest:
     definition: PipelineDefinition
     jobs: Sequence[BuildJob]
     execution: ExecutionConfig
+    command: Literal["build"] = field(default="build", init=False)
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -73,6 +74,7 @@ class MaterializeRunRequest:
     execution: ExecutionConfig
     artifact_settings: BuildSettings
     runtime: Runtime
+    command: Literal["materialize"] = field(default="materialize", init=False)
 
 
 ProfileRunRequest = BuildRunRequest | RuntimeRunRequest | MaterializeRunRequest

--- a/src/datapipeline/profiles/orchestration.py
+++ b/src/datapipeline/profiles/orchestration.py
@@ -1,4 +1,5 @@
 import logging
+import time
 
 from datapipeline.artifacts.errors import ArtifactResolutionError
 from datapipeline.artifacts.executor import run_build_if_needed
@@ -8,6 +9,9 @@ from datapipeline.artifacts.planning import (
     required_tick_artifacts,
 )
 from datapipeline.config.tasks import VectorInputsTask
+from datapipeline.cli.visuals.execution import route_execution_event
+from datapipeline.execution.events import RunStatus
+from datapipeline.execution.observability import CommandFinished
 from datapipeline.io.runs import (
     finish_run_failed,
     finish_run_success,
@@ -45,6 +49,8 @@ logger = logging.getLogger(__name__)
 
 
 def run_profiles(request: ProfileRunRequest) -> None:
+    started_at = time.perf_counter()
+    status: RunStatus = "error"
     try:
         with project_execution_lock(request.definition.project.artifacts_root):
             if isinstance(request, BuildRunRequest):
@@ -61,6 +67,17 @@ def run_profiles(request: ProfileRunRequest) -> None:
     except (ArtifactResolutionError, ProjectExecutionBusyError) as exc:
         logger.error("%s", exc)
         raise SystemExit(2) from exc
+    else:
+        status = "success"
+    finally:
+        route_execution_event(
+            CommandFinished(
+                command=request.command,
+                status=status,
+                elapsed_seconds=time.perf_counter() - started_at,
+            ),
+            logger,
+        )
 
 
 def _prune_vector_input_caches(request: ProfileRunRequest) -> None:

--- a/src/datapipeline/templates/plugin_skeleton/pyproject.toml
+++ b/src/datapipeline/templates/plugin_skeleton/pyproject.toml
@@ -7,7 +7,7 @@ name = "{{DIST_NAME}}"
 version = "0.0.1"
 description = "A DataPipeline plugin for the {{DIST_NAME}} domain"
 dependencies = [
-  "jerry-thomas>=5.0.4",
+  "jerry-thomas>=5.0.5",
 ]
 
 [project.entry-points."datapipeline.combiners"]

--- a/src/datapipeline/templates/plugin_skeleton/pyproject.toml
+++ b/src/datapipeline/templates/plugin_skeleton/pyproject.toml
@@ -7,7 +7,7 @@ name = "{{DIST_NAME}}"
 version = "0.0.1"
 description = "A DataPipeline plugin for the {{DIST_NAME}} domain"
 dependencies = [
-  "jerry-thomas>=5.0.3",
+  "jerry-thomas>=5.0.4",
 ]
 
 [project.entry-points."datapipeline.combiners"]

--- a/src/datapipeline/utils/time.py
+++ b/src/datapipeline/utils/time.py
@@ -49,6 +49,18 @@ def floor_time_to_cadence(ts: datetime, cadence: timedelta) -> datetime:
     return floored.astimezone(ts.tzinfo)
 
 
+def count_cadence_buckets(
+    start: datetime,
+    end: datetime,
+    cadence: timedelta,
+) -> int:
+    anchored_start = floor_time_to_cadence(start, cadence)
+    anchored_end = floor_time_to_cadence(end, cadence)
+    if anchored_end < anchored_start:
+        return 0
+    return ((anchored_end - anchored_start) // cadence) + 1
+
+
 def parse_datetime(value: str) -> datetime:
     """Parse an ISO-8601 datetime.
 

--- a/tests/unit/artifact_build/test_build_utils.py
+++ b/tests/unit/artifact_build/test_build_utils.py
@@ -16,7 +16,6 @@ from datapipeline.execution.context import PipelineContext
 from datapipeline.operations.artifacts import utils as artifact_utils
 from datapipeline.operations.artifacts.metadata import (
     _window_bounds_from_stats,
-    _window_size,
     materialize_metadata,
 )
 from datapipeline.operations.artifacts.schema import materialize_vector_schema
@@ -635,19 +634,3 @@ def test_window_bounds_preserve_single_timestamp() -> None:
         _hour(4),
         _hour(4),
     )
-
-
-def test_window_size_counts_cadence_buckets():
-    start = _hour(4)
-    end = _hour(10)
-
-    assert _window_size(start, end, "1h") == 7  # hours 4..10 inclusive
-    assert _window_size(start, end, "2h") == 4  # 4,6,8,10
-    assert _window_size(start, end, "15m") == 25  # 6 hours -> 360 minutes / 15 + 1
-
-
-def test_window_size_rejects_invalid_cadence():
-    timestamp = datetime(2024, 1, 1, tzinfo=timezone.utc)
-
-    with pytest.raises(ValueError, match="Unsupported cadence"):
-        _window_size(timestamp, timestamp, "0m")

--- a/tests/unit/artifact_build/test_build_utils.py
+++ b/tests/unit/artifact_build/test_build_utils.py
@@ -153,15 +153,15 @@ def test_collect_vector_metadata_emits_progress(monkeypatch, tmp_path):
         Sample(key=(0,), features=Vector(values={"price": 1.0})),
         Sample(key=(1,), features=Vector(values={"price": 2.0})),
     ]
-    trackers: list[tuple[str, float]] = []
+    trackers: list[tuple[str, str, float]] = []
     advances: list[int] = []
 
     class Progress:
-        def __init__(self, step: str, interval_seconds: float) -> None:
-            trackers.append((step, interval_seconds))
+        def __init__(self, step: str, unit: str, interval_seconds: float) -> None:
+            trackers.append((step, unit, interval_seconds))
 
-        def advance(self, items: int = 1) -> None:
-            advances.append(items)
+        def advance(self, count: int = 1) -> None:
+            advances.append(count)
 
     runtime.heartbeat_interval_seconds = 180
     monkeypatch.setattr(
@@ -179,7 +179,7 @@ def test_collect_vector_metadata_emits_progress(monkeypatch, tmp_path):
         "scan_features",
     )
 
-    assert trackers == [("scan_features", 180)]
+    assert trackers == [("scan_features", "vectors", 180)]
     assert advances == [1, 1]
 
 

--- a/tests/unit/cli/test_execution_observer.py
+++ b/tests/unit/cli/test_execution_observer.py
@@ -123,10 +123,11 @@ class _CaptureHandler:
                 name="build:schema",
                 step="write",
                 step_elapsed_seconds=1,
-                items=3,
+                completed=3,
+                unit="rows",
             ),
             logging.INFO,
-            "Operation build:schema · write · running elapsed=1s items=3",
+            "Operation build:schema · write · running elapsed=1s rows=3",
         ),
         (
             OperationStarted("serve:dataset"),
@@ -408,6 +409,7 @@ def test_operation_scope_emits_flat_lifecycle_result_and_progress(caplog) -> Non
                     "write_artifact",
                     1,
                     3,
+                    "rows",
                 )
     finally:
         reset_current_execution_event_handler(token)
@@ -424,7 +426,7 @@ def test_operation_scope_emits_flat_lifecycle_result_and_progress(caplog) -> Non
     assert "Operation build:model_grid started" in messages
     assert "Model grid: /tmp/model_grid.jsonl" in messages
     assert (
-        "Operation build:model_grid · write_artifact · running elapsed=1s items=3"
+        "Operation build:model_grid · write_artifact · running elapsed=1s rows=3"
         in messages
     )
     assert messages[-1].startswith("Operation build:model_grid finished status=success")

--- a/tests/unit/cli/test_execution_observer.py
+++ b/tests/unit/cli/test_execution_observer.py
@@ -25,6 +25,7 @@ from datapipeline.execution.events import (
     ProgressSnapshot,
 )
 from datapipeline.execution.observability import (
+    CommandFinished,
     FileResult,
     OperationFinished,
     OperationProgress,
@@ -56,6 +57,16 @@ class _CaptureHandler:
             FileResult("train_0", Path("/tmp/dataset.train_0.jsonl")),
             logging.INFO,
             "train_0: /tmp/dataset.train_0.jsonl",
+        ),
+        (
+            CommandFinished("serve", "success", 2.5),
+            logging.INFO,
+            "Command serve finished status=success elapsed=2.500000s",
+        ),
+        (
+            CommandFinished("serve", "error", 2.5),
+            logging.ERROR,
+            "Command serve finished status=error elapsed=2.500000s",
         ),
         (
             PipelineStarted(pipeline_name="pipeline", node_count=2),

--- a/tests/unit/cli/test_logging_setup.py
+++ b/tests/unit/cli/test_logging_setup.py
@@ -139,14 +139,14 @@ def test_operation_heartbeat_stays_in_file_during_visuals(tmp_path) -> None:
     try:
         with operation_observer(make_operation_observer(logger)):
             with operation_scope("serve:dataset"):
-                assert emit_operation_progress("write_output", 180, 2_592_885)
+                assert emit_operation_progress("write_output", 180, 2_592_885, "rows")
     finally:
         reset_current_execution_event_handler(token)
         _flush_root_handlers()
 
     content = log_path.read_text(encoding="utf-8")
     heartbeat = (
-        "Operation serve:dataset · write_output · running elapsed=180s items=2592885"
+        "Operation serve:dataset · write_output · running elapsed=180s rows=2592885"
     )
     assert content.count(heartbeat) == 1
     assert len(handler.events) == 3

--- a/tests/unit/cli/test_logging_setup.py
+++ b/tests/unit/cli/test_logging_setup.py
@@ -9,10 +9,12 @@ import datapipeline.execution.observability as observability
 from datapipeline.cli.logging_setup import (
     configure_root_logging,
     parse_log_output_specs,
+    root_logging_scope,
 )
 from datapipeline.cli.visuals.execution import (
     ExecutionMessage,
     make_operation_observer,
+    route_execution_event,
 )
 from datapipeline.cli.visuals.execution_context import (
     reset_current_execution_event_handler,
@@ -21,6 +23,7 @@ from datapipeline.cli.visuals.execution_context import (
     set_current_terminal_log_handler,
 )
 from datapipeline.execution.observability import (
+    CommandFinished,
     emit_file_result,
     emit_operation_progress,
     operation_observer,
@@ -184,6 +187,76 @@ def test_configure_root_logging_creates_file_on_first_record(tmp_path) -> None:
     _flush_root_handlers()
 
     assert log_path.read_text(encoding="utf-8") == "first record\n"
+
+
+def test_root_logging_scope_restores_command_outputs(tmp_path) -> None:
+    command_log = tmp_path / "command.log"
+    execution_log = tmp_path / "execution.log"
+    configure_root_logging(
+        level=logging.INFO,
+        output=LogOutputSettings(
+            outputs=(LogOutputTarget(transport="fs", destination=command_log),)
+        ),
+    )
+    logger = logging.getLogger("datapipeline.tests.logging_setup.scope")
+    root = logging.getLogger()
+    command_handlers = tuple(root.handlers)
+    command_level = root.level
+
+    with root_logging_scope(
+        logging.INFO,
+        LogOutputSettings(
+            outputs=(LogOutputTarget(transport="fs", destination=execution_log),)
+        ),
+    ):
+        execution_handlers = tuple(root.handlers)
+        logger.info("operation")
+
+    assert tuple(root.handlers) == command_handlers
+    assert root.level == command_level
+    assert all(
+        getattr(handler, "stream", None) is None for handler in execution_handlers
+    )
+    route_execution_event(CommandFinished("serve", "success", 1.5), logger)
+    _flush_root_handlers()
+
+    assert execution_log.read_text(encoding="utf-8") == "operation\n"
+    assert command_log.read_text(encoding="utf-8") == (
+        "Command serve finished status=success elapsed=1.500000s\n"
+    )
+
+
+def test_root_logging_scope_restores_command_outputs_after_failure(tmp_path) -> None:
+    command_log = tmp_path / "command-error.log"
+    execution_log = tmp_path / "execution-error.log"
+    configure_root_logging(
+        level=logging.INFO,
+        output=LogOutputSettings(
+            outputs=(LogOutputTarget(transport="fs", destination=command_log),)
+        ),
+    )
+    logger = logging.getLogger("datapipeline.tests.logging_setup.failed-scope")
+    root = logging.getLogger()
+    command_handlers = tuple(root.handlers)
+
+    with pytest.raises(RuntimeError, match="failed"):
+        with root_logging_scope(
+            logging.INFO,
+            LogOutputSettings(
+                outputs=(LogOutputTarget(transport="fs", destination=execution_log),)
+            ),
+        ):
+            logger.info("operation")
+            raise RuntimeError("failed")
+
+    assert tuple(root.handlers) == command_handlers
+    route_execution_event(CommandFinished("serve", "error", 1.5), logger)
+    _flush_root_handlers()
+
+    assert execution_log.read_text(encoding="utf-8") == "operation\n"
+    assert command_log.read_text(encoding="utf-8") == (
+        "Command serve finished status=error elapsed=1.500000s\n"
+    )
 
 
 def test_configure_root_logging_suppresses_terminal_execution_events_during_visuals(

--- a/tests/unit/cli/test_streams_rich.py
+++ b/tests/unit/cli/test_streams_rich.py
@@ -160,7 +160,6 @@ def test_info_progress_shows_node_and_local_detail() -> None:
 
     root, order_records, open_source = progress.tasks
     assert root.description == "[stream:adv.20]"
-    assert root.fields["show_bar"] is False
     assert root.total is None
     assert root.completed == 0
     assert root.fields["status"] == ""
@@ -169,6 +168,9 @@ def test_info_progress_shows_node_and_local_detail() -> None:
     assert open_source.visible is True
     assert open_source.completed == 20_000
     assert open_source.fields["status"] == ('2/17 "2011.jsonl" · 20,000 records')
+    assert _ProgressActivityColumn(Column()).render(open_source).plain == (
+        '2/17 "2011.jsonl" · 20,000 records'
+    )
 
     with patch.object(progress, "refresh", wraps=progress.refresh) as refresh:
         _finish_node(renderer, 1, "open_source")
@@ -316,15 +318,14 @@ def test_debug_progress_shows_root_and_active_nodes() -> None:
     assert [
         (
             task.description,
-            task.fields["show_bar"],
             task.fields["status"],
         )
         for task in tasks
     ] == [
-        ("[stream:adv.20]", False, ""),
-        ("[stream:adv.20/order_records]", True, "0 out"),
-        ("[stream:adv.20/open_source]", True, "25/100 records"),
-        ("[stream:adv.20/decode_records]", True, "0 out"),
+        ("[stream:adv.20]", ""),
+        ("[stream:adv.20/order_records]", "0 out"),
+        ("[stream:adv.20/open_source]", "25/100 records"),
+        ("[stream:adv.20/decode_records]", "0 out"),
     ]
     root_task, _, source_task, _ = tasks
     label = _ProgressLabelColumn(Column())
@@ -389,7 +390,6 @@ def test_operation_progress_stays_live_across_sequential_pipelines() -> None:
 
     operation = progress.tasks[0]
     assert operation.description == "Operation serve:dataset"
-    assert operation.fields["show_bar"] is False
     assert operation.fields["status"] == "write_output · 2,592,885 rows"
     assert _ProgressLabelColumn(Column()).render(operation).plain == (
         "Operation serve:dataset 0:00:10"

--- a/tests/unit/cli/test_streams_rich.py
+++ b/tests/unit/cli/test_streams_rich.py
@@ -390,18 +390,16 @@ def test_operation_progress_stays_live_across_sequential_pipelines() -> None:
     )
 
     operation = progress.tasks[0]
-    assert operation.description == "Operation serve:dataset"
+    assert operation.description == "Elapsed"
     assert operation.fields["status"] == "write_output · 2,592,885 rows"
-    assert _ProgressLabelColumn(Column()).render(operation).plain == (
-        "Operation serve:dataset 0:00:10"
-    )
+    assert _ProgressLabelColumn(Column()).render(operation).plain == ("Elapsed 0:00:10")
     assert _ProgressActivityColumn(Column()).render(operation).plain == (
         "write_output · 2,592,885 rows"
     )
 
     renderer.handle(PipelineStarted(pipeline_name="dataset:fold_0", node_count=5))
     assert [task.description for task in progress.tasks] == [
-        "Operation serve:dataset",
+        "Elapsed",
         "[dataset:fold_0]",
     ]
     renderer.handle(
@@ -413,11 +411,11 @@ def test_operation_progress_stays_live_across_sequential_pipelines() -> None:
             elapsed_seconds=1,
         )
     )
-    assert [task.description for task in progress.tasks] == ["Operation serve:dataset"]
+    assert [task.description for task in progress.tasks] == ["Elapsed"]
 
     renderer.handle(PipelineStarted(pipeline_name="dataset:fold_1", node_count=5))
     assert [task.description for task in progress.tasks] == [
-        "Operation serve:dataset",
+        "Elapsed",
         "[dataset:fold_1]",
     ]
     renderer.handle(OperationFinished("serve:dataset", "success", 20))
@@ -590,6 +588,7 @@ def test_rich_renderer_renders_operation_sequence_once_and_in_order() -> None:
 
     rendered = output.getvalue()
     markers = [
+        "Operation materialize:adv.20",
         "Config:",
         "[stream:adv.20] started",
         "[stream:adv.20] finished",
@@ -598,6 +597,7 @@ def test_rich_renderer_renders_operation_sequence_once_and_in_order() -> None:
     ]
     positions = [rendered.index(marker) for marker in markers]
     assert positions == sorted(positions)
+    assert rendered.count("Operation materialize:adv.20") == 2
     assert rendered.count("Config:") == 1
     assert "Operation materialize:adv.20 started" not in rendered
     assert progress_renderer.events == [
@@ -608,7 +608,7 @@ def test_rich_renderer_renders_operation_sequence_once_and_in_order() -> None:
     ]
 
 
-def test_rich_renderer_updates_operation_progress_without_printing() -> None:
+def test_rich_renderer_renders_operation_header_and_keeps_progress_live() -> None:
     console, output = _console()
     progress_renderer = _CaptureRenderer()
     renderer = _RichExecutionRenderer(logging.INFO, console, progress_renderer)
@@ -625,7 +625,8 @@ def test_rich_renderer_updates_operation_progress_without_printing() -> None:
     renderer.render(progress)
 
     assert progress_renderer.events == [started, progress]
-    assert output.getvalue() == ""
+    assert "Operation materialize:adv.20" in output.getvalue()
+    assert "Operation materialize:adv.20 started" not in output.getvalue()
 
 
 def test_rich_renderer_hides_plain_operation_start_at_warning() -> None:
@@ -637,7 +638,7 @@ def test_rich_renderer_hides_plain_operation_start_at_warning() -> None:
     assert output.getvalue() == ""
 
 
-def test_rich_renderer_keeps_live_operation_at_warning() -> None:
+def test_rich_renderer_keeps_live_operation_header_at_warning() -> None:
     console, output = _console()
     progress_renderer = _CaptureRenderer()
     renderer = _RichExecutionRenderer(logging.WARNING, console, progress_renderer)
@@ -646,7 +647,7 @@ def test_rich_renderer_keeps_live_operation_at_warning() -> None:
     renderer.render(event)
 
     assert progress_renderer.events == [event]
-    assert output.getvalue() == ""
+    assert "Operation materialize:adv.20" in output.getvalue()
 
 
 def test_rich_renderer_styles_only_final_status() -> None:

--- a/tests/unit/cli/test_streams_rich.py
+++ b/tests/unit/cli/test_streams_rich.py
@@ -327,11 +327,12 @@ def test_debug_progress_shows_root_and_active_nodes() -> None:
         ("[stream:adv.20/open_source]", "25/100 records"),
         ("[stream:adv.20/decode_records]", "0 out"),
     ]
-    root_task, _, source_task, _ = tasks
+    root_task, order_task, source_task, _ = tasks
     label = _ProgressLabelColumn(Column())
     activity_column = _ProgressActivityColumn(Column())
     assert label.render(root_task).plain == "[stream:adv.20] 0:00:00"
     assert activity_column.render(root_task).plain == ""
+    assert activity_column.render(order_task).plain == "0 out"
     assert source_task.completed == 25
     assert source_task.total == 100
     bar = activity_column._bar.render(source_task)

--- a/tests/unit/cli/test_streams_rich.py
+++ b/tests/unit/cli/test_streams_rich.py
@@ -382,19 +382,20 @@ def test_operation_progress_stays_live_across_sequential_pipelines() -> None:
             name="serve:dataset",
             step="write_output",
             step_elapsed_seconds=5,
-            items=2_592_885,
+            completed=2_592_885,
+            unit="rows",
         )
     )
 
     operation = progress.tasks[0]
     assert operation.description == "Operation serve:dataset"
     assert operation.fields["show_bar"] is False
-    assert operation.fields["status"] == "write_output · 2,592,885 items"
+    assert operation.fields["status"] == "write_output · 2,592,885 rows"
     assert _ProgressLabelColumn(Column()).render(operation).plain == (
         "Operation serve:dataset 0:00:10"
     )
     assert _ProgressActivityColumn(Column()).render(operation).plain == (
-        "write_output · 2,592,885 items"
+        "write_output · 2,592,885 rows"
     )
 
     renderer.handle(PipelineStarted(pipeline_name="dataset:fold_0", node_count=5))
@@ -615,7 +616,8 @@ def test_rich_renderer_updates_operation_progress_without_printing() -> None:
         name="materialize:adv.20",
         step="write_output",
         step_elapsed_seconds=60,
-        items=100,
+        completed=100,
+        unit="rows",
     )
 
     renderer.render(started)

--- a/tests/unit/execution/test_observability.py
+++ b/tests/unit/execution/test_observability.py
@@ -44,7 +44,7 @@ def test_observer_routes_operation_lifecycle_results_and_progress(monkeypatch) -
 
     assert current_operation_observer() is None
     assert emit_file_result("Output", Path("/tmp/out.jsonl")) is False
-    assert emit_operation_progress("outside", 1, 1) is False
+    assert emit_operation_progress("outside", 1, 1, "rows") is False
 
     with operation_observer(observer):
         assert current_operation_observer() is observer
@@ -53,7 +53,7 @@ def test_observer_routes_operation_lifecycle_results_and_progress(monkeypatch) -
             Path("/tmp/model_grid.jsonl"),
         )
         with operation_scope("build:model_grid"):
-            assert emit_operation_progress("write", 1, 3)
+            assert emit_operation_progress("write", 1, 3, "rows")
 
     assert current_operation_observer() is None
     assert observer.started == [OperationStarted("build:model_grid")]
@@ -72,7 +72,8 @@ def test_observer_routes_operation_lifecycle_results_and_progress(monkeypatch) -
             name="build:model_grid",
             step="write",
             step_elapsed_seconds=1,
-            items=3,
+            completed=3,
+            unit="rows",
         ),
     ]
 
@@ -89,7 +90,7 @@ def test_operation_scope_emits_failure_and_restores_progress_context(
             with operation_scope("serve:test"):
                 raise ValueError("  bad input  ")
 
-        assert emit_operation_progress("after", 1, 1) is False
+        assert emit_operation_progress("after", 1, 1, "rows") is False
 
     assert observer.started == [OperationStarted("serve:test")]
     assert observer.finished == [
@@ -105,19 +106,24 @@ def test_operation_scope_emits_failure_and_restores_progress_context(
     assert observer.progress == []
 
 
-def test_operation_progress_tracker_preserves_interval_and_item_counts(
+def test_operation_progress_tracker_preserves_interval_counts_and_unit(
     monkeypatch,
 ) -> None:
     times = iter((0.0, 0.5, 1.0, 1.4, 2.1))
     monkeypatch.setattr(observability.time, "perf_counter", lambda: next(times))
-    emitted: list[tuple[str, float, int]] = []
+    emitted: list[tuple[str, float, int, str]] = []
 
-    def capture_progress(step: str, elapsed_seconds: float, items: int) -> bool:
-        emitted.append((step, elapsed_seconds, items))
+    def capture_progress(
+        step: str,
+        elapsed_seconds: float,
+        completed: int,
+        unit: str,
+    ) -> bool:
+        emitted.append((step, elapsed_seconds, completed, unit))
         return True
 
     monkeypatch.setattr(observability, "emit_operation_progress", capture_progress)
-    progress = OperationProgressTracker("write", interval_seconds=1)
+    progress = OperationProgressTracker("write", "rows", interval_seconds=1)
 
     progress.advance(2)
     progress.advance()
@@ -125,11 +131,11 @@ def test_operation_progress_tracker_preserves_interval_and_item_counts(
     progress.advance()
 
     assert emitted == [
-        ("write", 1.0, 3),
-        ("write", 2.1, 8),
+        ("write", 1.0, 3, "rows"),
+        ("write", 2.1, 8, "rows"),
     ]
 
 
 def test_operation_progress_tracker_rejects_negative_interval() -> None:
     with pytest.raises(ValueError, match="interval_seconds must be non-negative"):
-        OperationProgressTracker("write", interval_seconds=-0.1)
+        OperationProgressTracker("write", "rows", interval_seconds=-0.1)

--- a/tests/unit/pipeline/test_pipeline_stages.py
+++ b/tests/unit/pipeline/test_pipeline_stages.py
@@ -3,6 +3,7 @@ from dataclasses import replace
 from datetime import datetime, timezone
 from pathlib import Path
 from types import SimpleNamespace
+from zoneinfo import ZoneInfo
 
 import pytest
 
@@ -29,14 +30,22 @@ from datapipeline.domain.sample import Sample
 from datapipeline.domain.sample_key import SampleKeyContract
 from datapipeline.domain.vector import Vector
 from datapipeline.execution.context import PipelineContext
-from datapipeline.execution.events import NodeStarted, PipelineEvent, PipelineStarted
+from datapipeline.execution.events import (
+    NodeStarted,
+    PipelineEvent,
+    PipelineStarted,
+    ProgressSnapshot,
+)
 from datapipeline.execution.node import SourceNode
 from datapipeline.execution.runner import run_pipeline
 from datapipeline.operations.artifacts.vector_inputs import materialize_vector_inputs
 from datapipeline.operations.runtime.pipeline import _record_preview_stream
 from datapipeline.parsers.identity import IdentityParser
 from datapipeline.pipelines.dataset.nodes import apply_postprocess
-from datapipeline.pipelines.dataset.pipeline import run_dataset_pipeline
+from datapipeline.pipelines.dataset.pipeline import (
+    build_dataset_pipeline,
+    run_dataset_pipeline,
+)
 from datapipeline.pipelines.feature.pipeline import (
     build_feature_pipeline,
     run_feature_pipeline,
@@ -46,7 +55,10 @@ from datapipeline.pipelines.stream.pipeline import (
     run_stream_pipeline,
 )
 from datapipeline.pipelines.vector import pipeline as vector_pipeline
-from datapipeline.pipelines.vector.nodes import sample_domain_window_keys, window_keys
+from datapipeline.pipelines.vector.keygen import (
+    sample_domain_key_plan,
+    window_key_plan,
+)
 from datapipeline.pipelines.vector.pipeline import build_vector_pipeline
 from datapipeline.runtime import (
     AlignedRuntimeStream,
@@ -73,37 +85,121 @@ def _ts(hour: int, minute: int = 0) -> datetime:
     return datetime(2024, 1, 1, hour=hour, minute=minute, tzinfo=timezone.utc)
 
 
-def test_sample_domain_window_keys_emit_sorted_composite_keys() -> None:
+def test_window_key_plan_counts_inclusive_cadence_buckets() -> None:
+    plan = window_key_plan(_ts(0, 10), _ts(2, 50), "1h")
+
+    assert plan is not None
+    keys = tuple(plan.keys())
+    assert keys == ((_ts(0),), (_ts(1),), (_ts(2),))
+    assert plan.total == len(keys) == 3
+
+
+def test_sample_domain_key_plan_counts_clipped_composite_keys() -> None:
     domain = [
-        SampleDomainEntry(key=["MSFT"], start=_ts(0), end=_ts(1)),
-        SampleDomainEntry(key=["AAPL"], start=_ts(1), end=_ts(1)),
+        SampleDomainEntry(key=["MSFT"], start=_ts(0, 30), end=_ts(2, 59)),
+        SampleDomainEntry(key=["AAPL"], start=_ts(2, 15), end=_ts(4, 30)),
+        SampleDomainEntry(key=["GOOG"], start=_ts(4), end=_ts(4, 30)),
     ]
 
-    keys = list(
-        sample_domain_window_keys(
-            _ts(0),
-            _ts(2),
-            "1h",
-            ["security_id"],
-            domain,
-        )
+    plan = sample_domain_key_plan(
+        _ts(1, 15),
+        _ts(3, 45),
+        "1h",
+        ["security_id"],
+        domain,
     )
 
-    assert keys == [
-        (_ts(0), "MSFT"),
-        (_ts(1), "AAPL"),
+    assert plan is not None
+    keys = tuple(plan.keys())
+    assert keys == (
         (_ts(1), "MSFT"),
+        (_ts(2), "AAPL"),
+        (_ts(2), "MSFT"),
+        (_ts(3), "AAPL"),
+    )
+    assert plan.total == len(keys) == 4
+
+
+def test_sample_domain_key_plan_counts_fall_back_lattice_keys() -> None:
+    timezone_ny = ZoneInfo("America/New_York")
+    plan = sample_domain_key_plan(
+        datetime(2024, 11, 3, 0, 7, tzinfo=timezone_ny),
+        datetime(2024, 11, 3, 6, 48, tzinfo=timezone_ny),
+        "2h",
+        ["security_id"],
+        [
+            SampleDomainEntry(
+                key=["AAPL"],
+                start=datetime(2024, 11, 3, 3, 8, tzinfo=timezone_ny),
+                end=datetime(2024, 11, 3, 6, 48, tzinfo=timezone_ny),
+            )
+        ],
+    )
+
+    assert plan is not None
+    keys = tuple(plan.keys())
+    assert [(key[0].isoformat(), key[1]) for key in keys] == [
+        ("2024-11-03T04:00:00-05:00", "AAPL")
     ]
+    assert plan.total == len(keys) == 1
+
+
+def test_sample_domain_key_plan_counts_spring_forward_lattice_keys() -> None:
+    timezone_ny = ZoneInfo("America/New_York")
+    plan = sample_domain_key_plan(
+        datetime(2024, 3, 10, 0, 7, tzinfo=timezone_ny),
+        datetime(2024, 3, 10, 4, 48, tzinfo=timezone_ny),
+        "2h",
+        ["security_id"],
+        [
+            SampleDomainEntry(
+                key=["AAPL"],
+                start=datetime(2024, 3, 10, 4, 8, tzinfo=timezone_ny),
+                end=datetime(2024, 3, 10, 4, 57, tzinfo=timezone_ny),
+            )
+        ],
+    )
+
+    assert plan is not None
+    keys = tuple(plan.keys())
+    assert keys == ()
+    assert plan.total == len(keys) == 0
+
+
+def test_sample_domain_key_plan_omits_total_for_mixed_time_lattices() -> None:
+    timezone_ny = ZoneInfo("America/New_York")
+    fixed_offset_end = datetime.fromisoformat("2024-11-03T04:00:00-05:00")
+    plan = sample_domain_key_plan(
+        datetime(2024, 11, 3, 0, tzinfo=timezone_ny),
+        fixed_offset_end,
+        "2h",
+        ["security_id"],
+        [
+            SampleDomainEntry(
+                key=["AAPL"],
+                start=datetime(2024, 11, 3, 0, tzinfo=timezone_ny),
+                end=fixed_offset_end,
+            )
+        ],
+    )
+
+    assert plan is not None
+    keys = tuple(plan.keys())
+    assert [(key[0].isoformat(), key[1]) for key in keys] == [
+        ("2024-11-03T00:00:00-04:00", "AAPL"),
+        ("2024-11-03T02:00:00-05:00", "AAPL"),
+    ]
+    assert plan.total is None
 
 
 def test_window_keys_rejects_invalid_cadence() -> None:
     with pytest.raises(ValueError, match="Unsupported cadence"):
-        window_keys(_ts(0), _ts(1), "0m")
+        window_key_plan(_ts(0), _ts(1), "0m")
 
 
 def test_sample_domain_window_keys_rejects_invalid_cadence() -> None:
     with pytest.raises(ValueError, match="Unsupported cadence"):
-        sample_domain_window_keys(
+        sample_domain_key_plan(
             _ts(0),
             _ts(1),
             "0m",
@@ -114,7 +210,7 @@ def test_sample_domain_window_keys_rejects_invalid_cadence() -> None:
 
 def test_sample_domain_window_keys_rejects_mismatched_key_width() -> None:
     with pytest.raises(ValueError, match="key length"):
-        sample_domain_window_keys(
+        sample_domain_key_plan(
             _ts(0),
             _ts(1),
             "1h",
@@ -712,12 +808,75 @@ def test_dataset_pipeline_matches_vector_and_postprocess_chain(tmp_path: Path) -
     cfg = FeatureRecordConfig(stream="stream", id="price", field="value")
     register_vector_inputs(runtime, [cfg], "1h")
 
+    pipeline = build_dataset_pipeline(
+        ctx,
+        [cfg],
+        "1h",
+        rectangular=False,
+    )
+    source = pipeline.nodes[0]
+    assert isinstance(source, SourceNode)
+    assert source.progress is None
+
     dataset_out = list(run_dataset_pipeline(ctx, [cfg], "1h", rectangular=False))
 
     manual = build_vector_pipeline(ctx, [cfg], "1h", rectangular=False)
     manual_out = list(apply_postprocess(ctx, manual))
 
     assert dataset_out == manual_out
+
+
+def test_rectangular_dataset_source_reports_exact_sample_total(tmp_path: Path) -> None:
+    runtime = _runtime_with_rows(tmp_path, [])
+    runtime.window_bounds = (_ts(0, 10), _ts(2, 50))
+    _register_price_schema(runtime)
+    context = PipelineContext(runtime)
+    cfg = FeatureRecordConfig(stream="stream", id="price", field="value")
+
+    pipeline = build_dataset_pipeline(context, [cfg], "1h")
+
+    source = pipeline.nodes[0]
+    assert isinstance(source, SourceNode)
+    assert source.progress is not None
+    assert source.progress(1) == ProgressSnapshot(
+        completed=1,
+        total=3,
+        unit="samples",
+    )
+
+
+def test_rectangular_features_and_targets_share_every_planned_key(
+    tmp_path: Path,
+) -> None:
+    runtime = _runtime_with_rows(
+        tmp_path,
+        [
+            {"time": _ts(0), "value": 1.0, "target": 10.0},
+            {"time": _ts(2), "value": 3.0, "target": 30.0},
+        ],
+    )
+    runtime.window_bounds = (_ts(0), _ts(2))
+    feature = FeatureRecordConfig(stream="stream", id="price", field="value")
+    target = FeatureRecordConfig(stream="stream", id="return", field="target")
+    register_vector_inputs(runtime, [feature], "1h", targets=[target])
+
+    samples = list(
+        build_vector_pipeline(
+            PipelineContext(runtime),
+            [feature],
+            "1h",
+            target_configs=[target],
+        )
+    )
+
+    assert [sample.key for sample in samples] == [
+        (_ts(0),),
+        (_ts(1),),
+        (_ts(2),),
+    ]
+    assert samples[1].features.values == {}
+    assert samples[1].targets is not None
+    assert samples[1].targets.values == {}
 
 
 def test_vector_inputs_artifact_feeds_serve_pipeline(tmp_path: Path) -> None:

--- a/tests/unit/pipeline/test_pipeline_stages.py
+++ b/tests/unit/pipeline/test_pipeline_stages.py
@@ -826,23 +826,46 @@ def test_dataset_pipeline_matches_vector_and_postprocess_chain(tmp_path: Path) -
     assert dataset_out == manual_out
 
 
-def test_rectangular_dataset_source_reports_exact_sample_total(tmp_path: Path) -> None:
+def test_rectangular_dataset_source_reuses_its_key_plan(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     runtime = _runtime_with_rows(tmp_path, [])
     runtime.window_bounds = (_ts(0, 10), _ts(2, 50))
     _register_price_schema(runtime)
     context = PipelineContext(runtime)
     cfg = FeatureRecordConfig(stream="stream", id="price", field="value")
+    feature_configs = [cfg]
+    register_vector_inputs(runtime, feature_configs, "1h")
 
-    pipeline = build_dataset_pipeline(context, [cfg], "1h")
+    original = vector_pipeline.rectangular_key_plan
+    plan_count = 0
+
+    def count_plans(pipeline_context, cadence, sample_keys):
+        nonlocal plan_count
+        plan_count += 1
+        return original(pipeline_context, cadence, sample_keys)
+
+    monkeypatch.setattr(vector_pipeline, "rectangular_key_plan", count_plans)
+
+    pipeline = build_dataset_pipeline(context, feature_configs, "1h")
+    feature_configs.clear()
 
     source = pipeline.nodes[0]
     assert isinstance(source, SourceNode)
     assert source.progress is not None
-    assert source.progress(1) == ProgressSnapshot(
-        completed=1,
-        total=3,
+    samples = list(source.open())
+    assert [sample.key for sample in samples] == [
+        (_ts(0),),
+        (_ts(1),),
+        (_ts(2),),
+    ]
+    assert source.progress(len(samples)) == ProgressSnapshot(
+        completed=3,
+        total=len(samples),
         unit="samples",
     )
+    assert plan_count == 1
 
 
 def test_rectangular_features_and_targets_share_every_planned_key(
@@ -1413,7 +1436,11 @@ def test_vector_inputs_rejects_symlinked_output_before_mutation(tmp_path: Path) 
     assert victim.read_text(encoding="utf-8") == "keep"
 
 
-def test_vector_pipeline_requires_vector_inputs_artifact(tmp_path: Path) -> None:
+@pytest.mark.parametrize("rectangular", [False, True])
+def test_vector_pipeline_requires_vector_inputs_artifact(
+    tmp_path: Path,
+    rectangular: bool,
+) -> None:
     runtime = _runtime_with_rows(
         tmp_path,
         rows=[{"time": _ts(0), "value": 1.0}],
@@ -1422,7 +1449,7 @@ def test_vector_pipeline_requires_vector_inputs_artifact(tmp_path: Path) -> None
     cfg = FeatureRecordConfig(stream="stream", id="price", field="value")
 
     with pytest.raises(RuntimeError, match="Vector inputs artifact is required"):
-        list(build_vector_pipeline(context, [cfg], "1h", rectangular=False))
+        list(build_vector_pipeline(context, [cfg], "1h", rectangular=rectangular))
 
 
 def test_cached_vector_pipeline_rejects_manifest_cadence_mismatch(

--- a/tests/unit/pipeline/test_postprocess.py
+++ b/tests/unit/pipeline/test_postprocess.py
@@ -65,6 +65,7 @@ def test_dataset_pipeline_assembles_before_postprocess(tmp_path) -> None:
         "normalize_features",
         "reject_undeclared_targets",
     ]
+    assert pipeline.nodes[0].progress is None
 
 
 def test_postprocess_has_one_explicit_execution_order(tmp_path) -> None:

--- a/tests/unit/profiles/test_executor.py
+++ b/tests/unit/profiles/test_executor.py
@@ -1,4 +1,4 @@
-from contextlib import contextmanager
+from contextlib import contextmanager, nullcontext
 from pathlib import Path
 
 import pytest
@@ -32,9 +32,14 @@ def test_run_execution_configures_logging_and_runs_work_inside_visuals(monkeypat
     calls = []
     inside_visual_context = False
 
+    @contextmanager
+    def root_logging_scope(level, output):
+        calls.append(("logging", level, output))
+        yield
+
     monkeypatch.setattr(
-        "datapipeline.profiles.executor.configure_root_logging",
-        lambda level, output: calls.append(("logging", level, output)),
+        "datapipeline.profiles.executor.root_logging_scope",
+        root_logging_scope,
     )
 
     monkeypatch.setattr(
@@ -98,8 +103,8 @@ def test_run_execution_uses_plain_context_when_visuals_are_unavailable(
 ) -> None:
     runtime = _runtime()
     monkeypatch.setattr(
-        "datapipeline.profiles.executor.configure_root_logging",
-        lambda **_kwargs: None,
+        "datapipeline.profiles.executor.root_logging_scope",
+        lambda *_args, **_kwargs: nullcontext(),
     )
     monkeypatch.setattr(
         "datapipeline.profiles.executor.rich_visuals_supported",
@@ -137,8 +142,8 @@ def test_run_execution_observes_nodes_for_debug_logging(monkeypatch) -> None:
     runtime = _runtime()
     runtime.observe_node_events = False
     monkeypatch.setattr(
-        "datapipeline.profiles.executor.configure_root_logging",
-        lambda **_kwargs: None,
+        "datapipeline.profiles.executor.root_logging_scope",
+        lambda *_args, **_kwargs: nullcontext(),
     )
     monkeypatch.setattr(
         "datapipeline.profiles.executor.rich_visuals_supported",
@@ -169,8 +174,8 @@ def test_run_execution_observes_nodes_for_debug_logging(monkeypatch) -> None:
 def test_run_execution_restores_observation_after_failure(monkeypatch) -> None:
     runtime = _runtime()
     monkeypatch.setattr(
-        "datapipeline.profiles.executor.configure_root_logging",
-        lambda **_kwargs: None,
+        "datapipeline.profiles.executor.root_logging_scope",
+        lambda *_args, **_kwargs: nullcontext(),
     )
 
     def fail() -> None:
@@ -201,8 +206,8 @@ def test_run_execution_preserves_existing_pipeline_observer(monkeypatch) -> None
     runtime.pipeline_observer = existing_observer
     runtime.observe_node_events = False
     monkeypatch.setattr(
-        "datapipeline.profiles.executor.configure_root_logging",
-        lambda **_kwargs: None,
+        "datapipeline.profiles.executor.root_logging_scope",
+        lambda *_args, **_kwargs: nullcontext(),
     )
     monkeypatch.setattr(
         "datapipeline.profiles.executor.rich_visuals_supported",

--- a/tests/unit/profiles/test_orchestration.py
+++ b/tests/unit/profiles/test_orchestration.py
@@ -40,6 +40,7 @@ from datapipeline.execution.settings import (
     LogOutputSettings,
     ObservabilitySettings,
 )
+from datapipeline.execution.observability import CommandFinished
 from datapipeline.io.output import OutputTarget
 from datapipeline.io.runs import RunPaths
 from datapipeline.profiles.execution import (
@@ -246,6 +247,108 @@ def _assert_preflight_rejected(request: BuildRunRequest | RuntimeRunRequest) -> 
     with pytest.raises(SystemExit) as exc:
         run_profiles(request)
     assert exc.value.code == 2
+
+
+def test_run_profiles_emits_one_command_summary(monkeypatch, tmp_path: Path) -> None:
+    requests = (
+        _build_request(tmp_path, [], []),
+        _runtime_request(
+            tmp_path,
+            command="serve",
+            artifact_tasks=[],
+            jobs=[],
+        ),
+        _runtime_request(
+            tmp_path,
+            command="inspect",
+            artifact_tasks=[],
+            jobs=[],
+        ),
+        _materialize_request(tmp_path, [], [], _runtime(tmp_path)),
+    )
+    times = iter((0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0))
+    events: list[CommandFinished] = []
+    monkeypatch.setattr(
+        "datapipeline.profiles.orchestration.time.perf_counter",
+        lambda: next(times),
+    )
+    monkeypatch.setattr(
+        "datapipeline.profiles.orchestration.route_execution_event",
+        lambda event, _logger: events.append(event),
+    )
+
+    for request in requests:
+        run_profiles(request)
+
+    assert events == [
+        CommandFinished("build", "success", 1.0),
+        CommandFinished("serve", "success", 1.0),
+        CommandFinished("inspect", "success", 1.0),
+        CommandFinished("materialize", "success", 1.0),
+    ]
+
+
+def test_run_profiles_reports_failure_after_cleanup_error(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    request = _build_request(tmp_path, [], [])
+    times = iter((10.0, 11.0))
+    events: list[CommandFinished] = []
+
+    def fail_prune(_request) -> None:
+        raise RuntimeError("prune failed")
+
+    monkeypatch.setattr(
+        "datapipeline.profiles.orchestration.time.perf_counter",
+        lambda: next(times),
+    )
+    monkeypatch.setattr(
+        "datapipeline.profiles.orchestration._prune_vector_input_caches",
+        fail_prune,
+    )
+    monkeypatch.setattr(
+        "datapipeline.profiles.orchestration.route_execution_event",
+        lambda event, _logger: events.append(event),
+    )
+
+    with pytest.raises(RuntimeError, match="prune failed"):
+        run_profiles(request)
+
+    assert events == [CommandFinished("build", "error", 1.0)]
+
+
+@pytest.mark.parametrize("error", [SystemExit(2), KeyboardInterrupt()])
+def test_run_profiles_preserves_process_control_exceptions(
+    monkeypatch,
+    tmp_path: Path,
+    error: BaseException,
+) -> None:
+    request = _build_request(tmp_path, [], [])
+    times = iter((10.0, 11.0))
+    events: list[CommandFinished] = []
+
+    def fail(_request) -> None:
+        raise error
+
+    monkeypatch.setattr(
+        "datapipeline.profiles.orchestration.time.perf_counter",
+        lambda: next(times),
+    )
+    monkeypatch.setattr(
+        "datapipeline.profiles.orchestration._run_build_profiles",
+        fail,
+    )
+    monkeypatch.setattr(
+        "datapipeline.profiles.orchestration.route_execution_event",
+        lambda event, _logger: events.append(event),
+    )
+
+    with pytest.raises(type(error)) as raised:
+        run_profiles(request)
+
+    assert raised.value is error
+    assert events == [CommandFinished("build", "error", 1.0)]
 
 
 def test_build_order_accepts_configured_dependency_order() -> None:

--- a/tests/unit/utils/test_time.py
+++ b/tests/unit/utils/test_time.py
@@ -1,8 +1,12 @@
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
-from datapipeline.utils.time import parse_cadence, parse_timecode
+from datapipeline.utils.time import (
+    count_cadence_buckets,
+    parse_cadence,
+    parse_timecode,
+)
 
 
 @pytest.mark.parametrize(
@@ -33,3 +37,17 @@ def test_parse_cadence_accepts_positive_dataset_units() -> None:
 def test_parse_cadence_rejects_values_outside_dataset_contract(value: str) -> None:
     with pytest.raises(ValueError, match="Unsupported cadence"):
         parse_cadence(value)
+
+
+@pytest.mark.parametrize(
+    ("cadence", "expected"),
+    [("1h", 7), ("2h", 4), ("15m", 25)],
+)
+def test_count_cadence_buckets_uses_inclusive_floored_bounds(
+    cadence: str,
+    expected: int,
+) -> None:
+    start = datetime(2024, 1, 1, 4, 5, tzinfo=timezone.utc)
+    end = datetime(2024, 1, 1, 10, 10, tzinfo=timezone.utc)
+
+    assert count_cadence_buckets(start, end, parse_cadence(cadence)) == expected


### PR DESCRIPTION
## Summary

- make operation, pipeline, node, and command lifecycle output consistent, with truthful units, elapsed time, and determinate bars only when an exact total is known
- centralize rectangular vector-key planning so progress totals and emitted keys share one immutable plan, including correct DST and mixed-cadence behavior
- clarify vector source construction and manifest ownership
- scope per-operation logging so command summaries return to command/global destinations instead of leaking into the final operation log
- bump Jerry Thomas and the generated plugin requirement to 5.0.5

## Why

Progress rendering previously mixed pipeline and node state, displayed generic item counts, and could present a determinate total that did not match the emitted sample domain. Vector output and progress also derived their plans separately. Operation logging permanently replaced root handlers, which made a command-level completion summary land in the wrong log destination.

The new structure gives each layer one responsibility: key planning owns both emitted keys and exact totals, operation execution owns temporary logging, and orchestration emits one final command result.

## Impact

Users get clearer execution output and exact progress where the total is provable. Unknown totals remain honest elapsed/count displays. Build, serve, inspect, and materialize now end with one command summary. There is no artifact-format revision change.

## Validation

- 1,525 tests pass with warnings treated as errors
- Ruff checks and formatting pass
- mypy passes across 261 source files
- `jerry_thomas-5.0.5-py3-none-any.whl` builds successfully
