### PR TITLE
Harden v5.0.7 pipeline correctness and scaffolding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,5 +37,6 @@ mutants/
 .idea/
 
 # Project-specific
+.jerry-scaffold.lock
 src/datapipeline.egg-info/
 tests/fixtures/**/build/

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -129,7 +129,7 @@ filtering.
     combine function receives one matching record from each input in the
     selected order and returns one record or `None`.
   - `--identity` applies only to source-backed streams.
-- `jerry source create <provider>.<dataset> --transport fs|http|synthetic --format csv|json|jsonl|pickle`
+- `jerry source create <provider>.<dataset> --transport fs|http|synthetic --format csv|json|jsonl|pickle` (`pickle` requires `fs`)
   - Also supports positional `<provider> <dataset>` and `--alias <provider>.<dataset>`.
   - Creates a source YAML only (no Python code).
 - `jerry domain create <name>` (also supports `-n/--name`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "jerry-thomas"
-version = "5.0.6"
+version = "5.0.7"
 description = "Jerry-Thomas: a stream-first, plugin-friendly data pipeline (mixology-themed CLI)"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"
@@ -48,6 +48,7 @@ exclude = ["datapipeline.templates*"]
 [tool.setuptools.package-data]
 datapipeline = [
   "templates/plugin_skeleton/**",
+  "templates/plugin_skeleton/.gitignore",
   "templates/dataset_skeleton/**",
   "templates/dataset_skeleton/your-dataset/.env.example",
   "templates/demo_skeleton/**",

--- a/src/datapipeline/artifacts/fingerprints.py
+++ b/src/datapipeline/artifacts/fingerprints.py
@@ -8,7 +8,6 @@ from pathlib import Path
 from datapipeline.artifacts.planning import build_artifact_graph
 from datapipeline.artifacts.specs import dataset_requires_scaler
 from datapipeline.config.dataset.dataset import FeatureDatasetConfig
-from datapipeline.config.dataset.split import SplitConfig
 from datapipeline.config.sources import CoreIoLoaderConfig, FsSourceArgs, SourceConfig
 from datapipeline.config.streams import SourceStreamConfig, StreamsConfig
 from datapipeline.config.tasks import (
@@ -23,7 +22,7 @@ from datapipeline.config.tasks import (
 from datapipeline.services.definitions import ArtifactHashes, ProjectManifest
 
 # Increment when Jerry's core artifact semantics change without a config change.
-ARTIFACT_CACHE_VERSION = 4
+ARTIFACT_CACHE_VERSION = 5
 
 
 def _normalized_label(path: Path, base_dir: Path) -> str:
@@ -164,7 +163,11 @@ def _artifact_inputs(
             {
                 "dataset": {
                     "sample": dataset.sample.model_dump(mode="json"),
-                    "split": _scaler_split_inputs(dataset.split),
+                    "split": (
+                        dataset.split.model_dump(mode="json")
+                        if dataset.split is not None
+                        else None
+                    ),
                     "scaled_vectors": [
                         config.model_dump(mode="json", exclude={"sequence"})
                         for config in scaled
@@ -214,20 +217,6 @@ def _artifact_inputs(
         },
         set(streams.sources),
     )
-
-
-def _scaler_split_inputs(split: SplitConfig | None) -> dict[str, object] | None:
-    if split is None:
-        return None
-    config = split.model_dump(mode="json", exclude={"folds"})
-    config["folds"] = [
-        {
-            "id": fold.id,
-            "train": list(fold.train),
-        }
-        for fold in split.folds
-    ]
-    return config
 
 
 def _artifact_digest(

--- a/src/datapipeline/cli/commands/mapper.py
+++ b/src/datapipeline/cli/commands/mapper.py
@@ -10,19 +10,27 @@ from datapipeline.cli.prompts import (
 from datapipeline.services.scaffold.discovery import list_domains, list_dtos
 from datapipeline.services.scaffold.domain import (
     create_domain,
+    domain_scaffold_paths,
     validate_domain_creation,
 )
-from datapipeline.services.scaffold.dto import create_dto, validate_dto_creation
+from datapipeline.services.scaffold.dto import (
+    create_dto,
+    dto_scaffold_paths,
+    validate_dto_creation,
+)
 from datapipeline.services.scaffold.layout import (
     default_mapper_name,
     default_mapper_name_for_identity,
     dto_module_path,
 )
+from datapipeline.services.scaffold.locking import acquire_scaffold_lock
 from datapipeline.services.scaffold.mapper import (
     create_mapper,
+    mapper_scaffold_paths,
     validate_mapper_creation,
 )
 from datapipeline.services.scaffold.paths import pkg_root
+from datapipeline.services.scaffold.utils import rollback_new_scaffold_paths
 
 logger = logging.getLogger(__name__)
 
@@ -35,13 +43,13 @@ def handle(name: str | None, *, plugin_root: Path | None = None) -> str:
             ("identity", "Any"),
         ],
     )
+    _, package_name, pyproject = pkg_root(plugin_root)
 
     dto_to_create = None
     if input_choice == "dto":
         dto_map = list_dtos(root=plugin_root)
         dto_class, should_create_dto = choose_dto(sorted(dto_map))
         if should_create_dto:
-            _, package_name, _ = pkg_root(plugin_root)
             dto_module = dto_module_path(package_name, dto_class)
             dto_to_create = dto_class
         else:
@@ -67,23 +75,39 @@ def handle(name: str | None, *, plugin_root: Path | None = None) -> str:
                 "Mapper name", default=default_mapper_name(input_module, domain)
             )
 
+    paths = list(mapper_scaffold_paths(name, plugin_root))
+    if dto_to_create is not None:
+        paths.extend(dto_scaffold_paths(dto_to_create, plugin_root))
+    if should_create_domain:
+        paths.extend(domain_scaffold_paths(domain, plugin_root))
     try:
-        if dto_to_create is not None:
-            validate_dto_creation(dto_to_create, plugin_root)
-        if should_create_domain:
-            validate_domain_creation(domain, plugin_root)
-        validate_mapper_creation(name, plugin_root)
-        if dto_to_create is not None:
-            create_dto(dto_to_create, plugin_root)
-        if should_create_domain:
-            create_domain(domain, plugin_root)
-        entrypoint = create_mapper(
-            name=name,
-            input_class=input_class,
-            input_module=input_module,
-            domain=domain,
-            root=plugin_root,
-        )
+        with acquire_scaffold_lock(pyproject.parent) as scaffold_lock:
+            if dto_to_create is not None:
+                validate_dto_creation(dto_to_create, plugin_root)
+            if should_create_domain:
+                validate_domain_creation(domain, plugin_root)
+            validate_mapper_creation(name, plugin_root)
+            with rollback_new_scaffold_paths(paths):
+                if dto_to_create is not None:
+                    create_dto(
+                        dto_to_create,
+                        plugin_root,
+                        scaffold_lock=scaffold_lock,
+                    )
+                if should_create_domain:
+                    create_domain(
+                        domain,
+                        plugin_root,
+                        scaffold_lock=scaffold_lock,
+                    )
+                entrypoint = create_mapper(
+                    name=name,
+                    input_class=input_class,
+                    input_module=input_module,
+                    domain=domain,
+                    root=plugin_root,
+                    scaffold_lock=scaffold_lock,
+                )
     except (FileExistsError, ValueError) as exc:
         raise SystemExit(str(exc)) from None
     logger.info("Mapper entry point: %s", entrypoint)

--- a/src/datapipeline/cli/commands/parser.py
+++ b/src/datapipeline/cli/commands/parser.py
@@ -3,13 +3,23 @@ from pathlib import Path
 
 from datapipeline.cli.prompts import choose_dto, choose_name
 from datapipeline.services.scaffold.discovery import list_dtos
-from datapipeline.services.scaffold.dto import create_dto, validate_dto_creation
-from datapipeline.services.scaffold.layout import default_parser_name, dto_module_path
+from datapipeline.services.scaffold.dto import (
+    create_dto,
+    dto_scaffold_paths,
+    validate_dto_creation,
+)
+from datapipeline.services.scaffold.layout import (
+    default_parser_name,
+    dto_module_path,
+)
+from datapipeline.services.scaffold.locking import acquire_scaffold_lock
 from datapipeline.services.scaffold.parser import (
     create_parser,
+    parser_scaffold_paths,
     validate_parser_creation,
 )
 from datapipeline.services.scaffold.paths import pkg_root
+from datapipeline.services.scaffold.utils import rollback_new_scaffold_paths
 
 logger = logging.getLogger(__name__)
 
@@ -25,7 +35,7 @@ def handle(
         f"{name}DTO" if name else None,
     )
 
-    _, package_name, _ = pkg_root(plugin_root)
+    _, package_name, pyproject = pkg_root(plugin_root)
     if should_create_dto:
         dto_module = dto_module_path(package_name, dto_class)
     else:
@@ -34,18 +44,28 @@ def handle(
     if not name:
         name = choose_name("Parser class name", default=default_parser_name(dto_class))
 
+    paths = list(parser_scaffold_paths(name, plugin_root))
+    if should_create_dto:
+        paths.extend(dto_scaffold_paths(dto_class, plugin_root))
     try:
-        if should_create_dto:
-            validate_dto_creation(dto_class, plugin_root)
-        validate_parser_creation(name, plugin_root)
-        if should_create_dto:
-            create_dto(dto_class, plugin_root)
-        entrypoint = create_parser(
-            name=name,
-            dto_class=dto_class,
-            dto_module=dto_module,
-            root=plugin_root,
-        )
+        with acquire_scaffold_lock(pyproject.parent) as scaffold_lock:
+            if should_create_dto:
+                validate_dto_creation(dto_class, plugin_root)
+            validate_parser_creation(name, plugin_root)
+            with rollback_new_scaffold_paths(paths):
+                if should_create_dto:
+                    create_dto(
+                        dto_class,
+                        plugin_root,
+                        scaffold_lock=scaffold_lock,
+                    )
+                entrypoint = create_parser(
+                    name=name,
+                    dto_class=dto_class,
+                    dto_module=dto_module,
+                    root=plugin_root,
+                    scaffold_lock=scaffold_lock,
+                )
     except (FileExistsError, ValueError) as exc:
         raise SystemExit(str(exc)) from None
     logger.info("Parser entry point: %s", entrypoint)

--- a/src/datapipeline/cli/commands/source.py
+++ b/src/datapipeline/cli/commands/source.py
@@ -178,15 +178,15 @@ def handle(
     source_id = f"{provider}.{dataset}"
     try:
         validate_source_id(source_id)
+        loader_ep, loader_args = _resolve_loader_config(
+            transport,
+            format,
+            loader,
+            plugin_root,
+        )
     except ValueError as exc:
         logger.error("%s", exc)
         raise SystemExit(2) from None
-    loader_ep, loader_args = _resolve_loader_config(
-        transport,
-        format,
-        loader,
-        plugin_root,
-    )
     parser_ep = _resolve_parser_entrypoint(identity, parser, plugin_root)
 
     project_yaml = resolve_default_project_yaml(workspace)

--- a/src/datapipeline/cli/parser/source.py
+++ b/src/datapipeline/cli/parser/source.py
@@ -52,7 +52,7 @@ def add_source_command(sub, common: argparse.ArgumentParser) -> None:
         "--format",
         "-f",
         choices=SOURCE_FS_FORMATS,
-        help="data format for fs/http transports (ignored otherwise)",
+        help="data format for fs/http transports; pickle requires fs",
     )
     create.add_argument(
         "--loader",

--- a/src/datapipeline/cli/visuals/rich/progress.py
+++ b/src/datapipeline/cli/visuals/rich/progress.py
@@ -43,15 +43,7 @@ from datapipeline.execution.observability import (
 )
 
 
-class _ProgressLabelColumn(ProgressColumn):
-    def render(self, task: Task) -> RenderableType:
-        label = Text(task.description)
-        elapsed = timedelta(seconds=int(task.elapsed or 0))
-        label.append(f" {elapsed}")
-        return label
-
-
-class _ProgressActivityColumn(ProgressColumn):
+class _ProgressRowColumn(ProgressColumn):
     def __init__(self, table_column: Column) -> None:
         super().__init__(table_column)
         self._bar = BarColumn(
@@ -63,12 +55,25 @@ class _ProgressActivityColumn(ProgressColumn):
         )
 
     def render(self, task: Task) -> RenderableType:
-        status = Text(task.fields["status"])
-        if task.total is None:
-            return status
-        activity = Table.grid(padding=(0, 1))
-        activity.add_row(self._bar.render(task), status)
-        return activity
+        row = Table.grid(padding=(0, 1))
+        row.add_column(overflow="ellipsis")
+        row.add_column(min_width=7, no_wrap=True)
+        cells: list[RenderableType] = [
+            Text(task.description, no_wrap=True, overflow="ellipsis"),
+            Text(
+                str(timedelta(seconds=int(task.elapsed or 0))),
+                style="cyan",
+            ),
+        ]
+        status = task.fields["status"]
+        if task.total is not None:
+            row.add_column(no_wrap=True)
+            cells.append(self._bar.render(task))
+        if status:
+            row.add_column(overflow="ellipsis")
+            cells.append(Text(status, no_wrap=True, overflow="ellipsis"))
+        row.add_row(*cells)
+        return row
 
 
 class _ExecutionProgress:
@@ -116,7 +121,7 @@ class _ExecutionProgress:
             raise RuntimeError("Cannot start overlapping operation progress")
         self._operation_name = event.name
         self._operation_task = self._progress.add_task(
-            "Elapsed",
+            f"Operation {event.name}",
             total=None,
             status="",
         )
@@ -129,7 +134,7 @@ class _ExecutionProgress:
         self._progress.update(
             self._operation_task,
             completed=event.completed,
-            status=f"{event.step} · {event.completed:,} {event.unit}",
+            status=f"last report: {event.step} · {event.completed:,} {event.unit}",
         )
 
     def _finish_operation(self, event: OperationFinished) -> None:
@@ -299,7 +304,7 @@ class _RichExecutionRenderer:
         table.add_column(no_wrap=True)
         table.add_column(ratio=1, overflow="fold")
         result = Text(str(event.path))
-        result.stylize(f"blue link {event.path.resolve().as_uri()}")
+        result.stylize(f"bright_blue link {event.path.resolve().as_uri()}")
         table.add_row(f"{event.label}:", result)
         return table
 
@@ -336,8 +341,7 @@ def visual_execution(log_level: int):
     console = Console(file=sys.stderr, markup=False, highlight=False)
     debug = log_level <= logging.DEBUG
     progress = Progress(
-        _ProgressLabelColumn(Column(no_wrap=True, overflow="ellipsis")),
-        _ProgressActivityColumn(Column(no_wrap=True, overflow="ellipsis")),
+        _ProgressRowColumn(Column(no_wrap=True, overflow="ellipsis")),
         transient=True,
         console=console,
         refresh_per_second=10,

--- a/src/datapipeline/config/observability.py
+++ b/src/datapipeline/config/observability.py
@@ -31,7 +31,7 @@ class LogOutputConfig(BaseModel):
         name = str(value).upper()
         if name not in VALID_LOG_TRANSPORTS:
             raise ValueError(
-                f"transport must be one of {', '.join(VALID_LOG_TRANSPORTS)}, got {value!r}"
+                f"transport must be one of {', '.join(VALID_LOG_TRANSPORTS)}"
             )
         return name
 
@@ -42,9 +42,7 @@ class LogOutputConfig(BaseModel):
             return "GLOBAL"
         name = str(value).upper()
         if name not in VALID_LOG_SCOPES:
-            raise ValueError(
-                f"scope must be one of {', '.join(VALID_LOG_SCOPES)}, got {value!r}"
-            )
+            raise ValueError(f"scope must be one of {', '.join(VALID_LOG_SCOPES)}")
         return name
 
     @field_validator("path", mode="before")
@@ -90,9 +88,7 @@ class LoggingConfig(BaseModel):
             return None
         name = str(value).upper()
         if name not in VALID_LOG_LEVELS:
-            raise ValueError(
-                f"level must be one of {', '.join(VALID_LOG_LEVELS)}, got {value!r}"
-            )
+            raise ValueError(f"level must be one of {', '.join(VALID_LOG_LEVELS)}")
         return name
 
 
@@ -124,6 +120,6 @@ class ObservabilityConfig(BaseModel):
         name = str(value).upper()
         if name not in VALID_VISUAL_PROVIDERS:
             raise ValueError(
-                f"visuals must be one of {', '.join(VALID_VISUAL_PROVIDERS)}, got {value!r}"
+                f"visuals must be one of {', '.join(VALID_VISUAL_PROVIDERS)}"
             )
         return name

--- a/src/datapipeline/config/profiles/base.py
+++ b/src/datapipeline/config/profiles/base.py
@@ -21,6 +21,8 @@ class Profile(BaseModel):
         text = str(value).strip() if value is not None else ""
         if not text:
             raise ValueError("profile name must be set")
+        if text in {".", ".."}:
+            raise ValueError("profile name must not be '.' or '..'")
         return text
 
 

--- a/src/datapipeline/config/profiles/build.py
+++ b/src/datapipeline/config/profiles/build.py
@@ -20,9 +20,7 @@ def normalize_artifact_mode(value: object) -> ArtifactMode | None:
         return "FORCE"
     if name == "OFF":
         return "OFF"
-    raise ValueError(
-        f"artifact mode must be one of {', '.join(ARTIFACT_MODES)}, got {value!r}"
-    )
+    raise ValueError(f"artifact mode must be one of {', '.join(ARTIFACT_MODES)}")
 
 
 class BuildProfile(Profile):

--- a/src/datapipeline/config/profiles/output.py
+++ b/src/datapipeline/config/profiles/output.py
@@ -86,5 +86,5 @@ class ServeOutputConfig(BaseModel):
                 try:
                     codecs.lookup(self.encoding)
                 except LookupError as exc:
-                    raise ValueError(f"Unknown encoding '{self.encoding}'") from exc
+                    raise ValueError("encoding must name a registered codec") from exc
         return self

--- a/src/datapipeline/config/tasks/ticks.py
+++ b/src/datapipeline/config/tasks/ticks.py
@@ -21,4 +21,6 @@ class TicksTask(ArtifactTask):
     def _validate_grid_by(cls, grid_by: list[str]) -> list[str]:
         if len(grid_by) != len(set(grid_by)):
             raise ValueError("grid_by must not contain duplicate fields")
+        if "time" in grid_by:
+            raise ValueError("grid_by must not contain the reserved field 'time'")
         return grid_by

--- a/src/datapipeline/domain/record.py
+++ b/src/datapipeline/domain/record.py
@@ -14,7 +14,7 @@ class TemporalRecord(Record):
     time: datetime
 
     def __post_init__(self) -> None:
-        if self.time.tzinfo is None:
+        if self.time.tzinfo is None or self.time.utcoffset() is None:
             raise ValueError("time must be timezone-aware")
         self.time = self.time.astimezone(timezone.utc)
 

--- a/src/datapipeline/execution/runner.py
+++ b/src/datapipeline/execution/runner.py
@@ -417,6 +417,7 @@ def _unobserved_node(
 ) -> Iterator[Any]:
     produced: Iterable[Any] = ()
     iterator: Iterator[Any] = iter(())
+    processing_failed = False
     try:
         produced = _open_node(node, upstream)
         if produced is None:
@@ -425,12 +426,19 @@ def _unobserved_node(
             )
         iterator = iter(produced)
         yield from iterator
+    except (Exception, KeyboardInterrupt):
+        processing_failed = True
+        raise
     finally:
-        _close_iterator(iterator)
-        if iterator is not produced:
-            _close_iterator(produced)
-        if upstream is not None and produced is not upstream:
-            _close_iterator(upstream)
+        try:
+            _close_iterator(iterator)
+            if iterator is not produced:
+                _close_iterator(produced)
+            if upstream is not None and produced is not upstream:
+                _close_iterator(upstream)
+        except BaseException:
+            if not processing_failed:
+                raise
 
 
 def _observed_node(
@@ -497,6 +505,7 @@ def _observed_node(
         error_message = _error_message(exc)
         raise
     finally:
+        node_failed = status == "error"
         close_error: BaseException | None = None
         try:
             _close_iterator(iterator)
@@ -506,9 +515,10 @@ def _observed_node(
                 _close_iterator(upstream)
         except BaseException as exc:
             close_error = exc
-            status = "error"
-            error_type = type(exc).__name__
-            error_message = _error_message(exc)
+            if not node_failed:
+                status = "error"
+                error_type = type(exc).__name__
+                error_message = _error_message(exc)
         finally:
             progress.clear(context)
 
@@ -525,5 +535,5 @@ def _observed_node(
                     error_message=error_message,
                 )
             )
-        if close_error is not None:
+        if not node_failed and close_error is not None:
             raise close_error

--- a/src/datapipeline/execution/runner.py
+++ b/src/datapipeline/execution/runner.py
@@ -281,12 +281,9 @@ def _run_observed(
                 break
             progress.output_items += 1
             yield item
-    except KeyboardInterrupt as exc:
-        status = "error"
-        error_type = type(exc).__name__
-        error_message = _error_message(exc)
+    except GeneratorExit:
         raise
-    except Exception as exc:
+    except BaseException as exc:
         status = "error"
         error_type = type(exc).__name__
         error_message = _error_message(exc)
@@ -426,7 +423,9 @@ def _unobserved_node(
             )
         iterator = iter(produced)
         yield from iterator
-    except (Exception, KeyboardInterrupt):
+    except GeneratorExit:
+        raise
+    except BaseException:
         processing_failed = True
         raise
     finally:
@@ -494,12 +493,9 @@ def _observed_node(
             output_items += 1
             progress_state.completed = output_items
             yield item
-    except KeyboardInterrupt as exc:
-        status = "error"
-        error_type = type(exc).__name__
-        error_message = _error_message(exc)
+    except GeneratorExit:
         raise
-    except Exception as exc:
+    except BaseException as exc:
         status = "error"
         error_type = type(exc).__name__
         error_message = _error_message(exc)

--- a/src/datapipeline/integrations/ml/adapter.py
+++ b/src/datapipeline/integrations/ml/adapter.py
@@ -5,6 +5,8 @@ from pathlib import Path
 from typing import Any, Literal
 
 from datapipeline.artifacts.hydration import hydrate_runtime_artifacts_for_pipeline
+from datapipeline.artifacts.models import VectorSchemaEntry
+from datapipeline.artifacts.registry import VECTOR_SCHEMA_SPEC
 from datapipeline.artifacts.specs import dataset_requires_scaler
 from datapipeline.config.dataset.dataset import FeatureDatasetConfig
 from datapipeline.config.dataset.split import (
@@ -16,6 +18,7 @@ from datapipeline.config.dataset.split import (
 from datapipeline.domain.sample import Sample
 from datapipeline.domain.vector import Vector
 from datapipeline.execution.context import PipelineContext
+from datapipeline.pipelines.dataset.nodes import build_postprocess_plan
 from datapipeline.pipelines.dataset.pipeline import (
     run_dataset_pipeline,
     run_fold_dataset_pipeline,
@@ -26,6 +29,22 @@ from datapipeline.services.pipeline import load_pipeline
 from datapipeline.services.runtime_compiler import compile_runtime
 
 GroupFormat = Literal["mapping", "tuple", "list", "flat"]
+
+
+def _schema_entry_columns(
+    entries: Sequence[VectorSchemaEntry],
+    flatten_sequences: bool,
+) -> list[str]:
+    columns: list[str] = []
+    for entry in entries:
+        if flatten_sequences and entry.kind == "list":
+            assert entry.cadence is not None
+            columns.extend(
+                f"{entry.id}[{index}]" for index in range(entry.cadence.target)
+            )
+        else:
+            columns.append(entry.id)
+    return columns
 
 
 def _normalize_group(
@@ -107,6 +126,8 @@ class VectorAdapter:
         group_column: str = "group",
         flatten_sequences: bool = False,
     ) -> Generator[dict[str, Any], None, None]:
+        if flatten_sequences:
+            self.row_columns(flatten_sequences=True)
         samples = self._samples(limit)
         sample_keys = self.dataset.sample.keys
         try:
@@ -129,6 +150,34 @@ class VectorAdapter:
                 yield row
         finally:
             samples.close()
+
+    def row_columns(
+        self,
+        flatten_sequences: bool = False,
+    ) -> tuple[list[str], list[str]]:
+        context = PipelineContext(self.runtime)
+        schema = context.require_artifact(VECTOR_SCHEMA_SPEC)
+        postprocess = build_postprocess_plan(context)
+        feature_by_id = {entry.id: entry for entry in schema.features}
+        target_by_id = {entry.id: entry for entry in schema.targets}
+        feature_columns = _schema_entry_columns(
+            [feature_by_id[identifier] for identifier in postprocess.feature_ids],
+            flatten_sequences,
+        )
+        target_columns = _schema_entry_columns(
+            [target_by_id[identifier] for identifier in postprocess.target_ids],
+            flatten_sequences,
+        )
+        if flatten_sequences:
+            seen: set[str] = set()
+            for column in [*feature_columns, *target_columns]:
+                if column in seen:
+                    raise ValueError(
+                        f"Flattened row column {column!r} is produced by multiple "
+                        "postprocessed schema entries."
+                    )
+                seen.add(column)
+        return feature_columns, target_columns
 
     def _samples(self, limit: int | None) -> Generator[Sample, None, None]:
         features = list(self.dataset.features)

--- a/src/datapipeline/integrations/ml/torch_support.py
+++ b/src/datapipeline/integrations/ml/torch_support.py
@@ -2,10 +2,6 @@ from collections.abc import Sequence
 from pathlib import Path
 from typing import Any, Mapping
 
-from datapipeline.artifacts.models import VectorSchemaEntry
-from datapipeline.artifacts.registry import VECTOR_SCHEMA_SPEC
-from datapipeline.execution.context import PipelineContext
-
 from .adapter import VectorAdapter
 
 
@@ -23,34 +19,6 @@ def _resolve_columns(
     if target_columns is None:
         target_columns = []
     return list(feature_columns), list(target_columns)
-
-
-def _schema_entry_columns(
-    entries: Sequence[VectorSchemaEntry],
-    flatten_sequences: bool,
-) -> list[str]:
-    columns: list[str] = []
-    for entry in entries:
-        if flatten_sequences and entry.kind == "list":
-            assert entry.cadence is not None
-            columns.extend(
-                f"{entry.id}[{index}]" for index in range(entry.cadence.target)
-            )
-        else:
-            columns.append(entry.id)
-    return columns
-
-
-def _schema_columns(
-    adapter: VectorAdapter,
-    flatten_sequences: bool = False,
-) -> tuple[list[str], list[str]]:
-    context = PipelineContext(adapter.runtime)
-    schema = context.require_artifact(VECTOR_SCHEMA_SPEC)
-    return (
-        _schema_entry_columns(schema.features, flatten_sequences),
-        _schema_entry_columns(schema.targets, flatten_sequences),
-    )
 
 
 def torch_dataset(
@@ -75,17 +43,15 @@ def torch_dataset(
         ) from exc
 
     adapter = VectorAdapter.from_project(project_yaml, output_id=output_id)
+    schema_feature_columns, schema_target_columns = adapter.row_columns(
+        flatten_sequences
+    )
     rows = list(
         adapter.iter_rows(
             limit=limit,
             include_group=False,
             flatten_sequences=flatten_sequences,
         )
-    )
-
-    schema_feature_columns, schema_target_columns = _schema_columns(
-        adapter,
-        flatten_sequences,
     )
     if feature_columns is None and schema_feature_columns:
         feature_columns = schema_feature_columns

--- a/src/datapipeline/integrations/ml/torch_support.py
+++ b/src/datapipeline/integrations/ml/torch_support.py
@@ -2,6 +2,7 @@ from collections.abc import Sequence
 from pathlib import Path
 from typing import Any, Mapping
 
+from datapipeline.artifacts.models import VectorSchemaEntry
 from datapipeline.artifacts.registry import VECTOR_SCHEMA_SPEC
 from datapipeline.execution.context import PipelineContext
 
@@ -24,12 +25,31 @@ def _resolve_columns(
     return list(feature_columns), list(target_columns)
 
 
-def _schema_columns(adapter: VectorAdapter) -> tuple[list[str], list[str]]:
+def _schema_entry_columns(
+    entries: Sequence[VectorSchemaEntry],
+    flatten_sequences: bool,
+) -> list[str]:
+    columns: list[str] = []
+    for entry in entries:
+        if flatten_sequences and entry.kind == "list":
+            assert entry.cadence is not None
+            columns.extend(
+                f"{entry.id}[{index}]" for index in range(entry.cadence.target)
+            )
+        else:
+            columns.append(entry.id)
+    return columns
+
+
+def _schema_columns(
+    adapter: VectorAdapter,
+    flatten_sequences: bool = False,
+) -> tuple[list[str], list[str]]:
     context = PipelineContext(adapter.runtime)
     schema = context.require_artifact(VECTOR_SCHEMA_SPEC)
     return (
-        [entry.id for entry in schema.features],
-        [entry.id for entry in schema.targets],
+        _schema_entry_columns(schema.features, flatten_sequences),
+        _schema_entry_columns(schema.targets, flatten_sequences),
     )
 
 
@@ -63,7 +83,10 @@ def torch_dataset(
         )
     )
 
-    schema_feature_columns, schema_target_columns = _schema_columns(adapter)
+    schema_feature_columns, schema_target_columns = _schema_columns(
+        adapter,
+        flatten_sequences,
+    )
     if feature_columns is None and schema_feature_columns:
         feature_columns = schema_feature_columns
     if target_columns is None:

--- a/src/datapipeline/io/normalization.py
+++ b/src/datapipeline/io/normalization.py
@@ -44,7 +44,7 @@ def flat_payload(item: Any) -> dict[str, Any]:
 
 def flatten_fields(prefix: str, value: Any, out: dict[str, Any]) -> None:
     if _is_scalar(value):
-        out[prefix] = value
+        _set_flat_field(out, prefix, value)
         return
     if isinstance(value, Mapping):
         for key, nested in sorted(value.items(), key=lambda kv: str(kv[0])):
@@ -53,11 +53,17 @@ def flatten_fields(prefix: str, value: Any, out: dict[str, Any]) -> None:
     if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
         if all(_is_scalar(item) for item in value):
             for idx, nested in enumerate(value):
-                out[f"{prefix}.{idx}"] = nested
+                _set_flat_field(out, f"{prefix}.{idx}", nested)
             return
-        out[prefix] = json_text(raw_payload(value))
+        _set_flat_field(out, prefix, json_text(raw_payload(value)))
         return
     raise TypeError(f"Unsupported output value type: {type(value).__name__}")
+
+
+def _set_flat_field(out: dict[str, Any], field: str, value: Any) -> None:
+    if field in out:
+        raise ValueError(f"Flat output field {field!r} is produced more than once.")
+    out[field] = value
 
 
 def _normalize_key_struct(key: Any) -> Any:

--- a/src/datapipeline/io/output.py
+++ b/src/datapipeline/io/output.py
@@ -53,8 +53,8 @@ class OutputTarget:
             return self
         safe_feature = sanitize_path_segment(str(feature_id), default="feature")
         dest = self.destination
-        suffix = "".join(dest.suffixes)
-        stem = dest.name[: -len(suffix)] if suffix else dest.name
+        suffix = _format_suffix(self.format)
+        stem = dest.name.removesuffix(suffix)
         new_name = f"{stem}.{safe_feature}{suffix}"
         new_path = dest.with_name(new_name)
         return replace(self, destination=new_path)
@@ -64,8 +64,8 @@ class OutputTarget:
             return self
         safe_output_id = sanitize_path_segment(output_id)
         dest = self.destination
-        suffix = "".join(dest.suffixes)
-        stem = dest.name[: -len(suffix)] if suffix else dest.name
+        suffix = _format_suffix(self.format)
+        stem = dest.name.removesuffix(suffix)
         new_name = f"{stem}.{safe_output_id}{suffix}"
         new_path = dest.with_name(new_name)
         return replace(self, destination=new_path)

--- a/src/datapipeline/io/sinks/files.py
+++ b/src/datapipeline/io/sinks/files.py
@@ -40,12 +40,13 @@ class AtomicTextFileSink:
         dest: Path,
         encoding: str = "utf-8",
         overwrite: bool = True,
+        newline: str | None = None,
     ):
         self._dest = dest
         self._overwrite = overwrite
         codecs.lookup(encoding)
         fd, self._tmp = _temporary_file(dest)
-        self._fh = os.fdopen(fd, "w", encoding=encoding)
+        self._fh = os.fdopen(fd, "w", encoding=encoding, newline=newline)
 
     @property
     def fh(self):

--- a/src/datapipeline/io/writers/csv_writer.py
+++ b/src/datapipeline/io/writers/csv_writer.py
@@ -8,7 +8,7 @@ from datapipeline.io.sinks.files import AtomicTextFileSink
 
 class CsvFileWriter:
     def __init__(self, dest: Path, encoding: str = "utf-8") -> None:
-        self.sink = AtomicTextFileSink(dest, encoding=encoding)
+        self.sink = AtomicTextFileSink(dest, encoding=encoding, newline="")
         self.writer = csv.writer(self.sink.fh)
         self._header_written = False
         self._projector = CsvTableProjector(flat_payload)

--- a/src/datapipeline/operations/persistence.py
+++ b/src/datapipeline/operations/persistence.py
@@ -105,6 +105,15 @@ def persist_artifact_output(
     return persisted
 
 
+def _close_runtime_rows(rows: Iterable[Any], logger: logging.Logger) -> None:
+    close = getattr(rows, "close", None)
+    if callable(close):
+        try:
+            close()
+        except Exception:
+            logger.debug("Failed to close runtime output rows", exc_info=True)
+
+
 def _persist_runtime_output(
     result: RuntimeOutput,
     *,
@@ -146,6 +155,7 @@ def _persist_runtime_output(
             rows = (dict(result.payload),)
 
     writer = writer_factory(effective_target)
+    rows = iter(rows)
     progress = OperationProgressTracker(
         "write_output",
         "rows",
@@ -159,6 +169,7 @@ def _persist_runtime_output(
         writer.close()
         success = True
     finally:
+        _close_runtime_rows(rows, logger)
         if not success:
             try:
                 writer.abort()
@@ -238,12 +249,7 @@ def _persist_routed_runtime_output(
             writer.close()
         success = True
     finally:
-        close_rows = getattr(rows, "close", None)
-        if callable(close_rows):
-            try:
-                close_rows()
-            except Exception:
-                logger.debug("Failed to close routed runtime rows", exc_info=True)
+        _close_runtime_rows(rows, logger)
         if not success:
             for writer in writers.values():
                 try:

--- a/src/datapipeline/operations/persistence.py
+++ b/src/datapipeline/operations/persistence.py
@@ -1,4 +1,6 @@
 import logging
+from collections.abc import Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Iterable, Mapping, Sequence
@@ -12,6 +14,7 @@ from datapipeline.execution.observability import (
 from datapipeline.io.factory import writer_factory
 from datapipeline.io.normalization import json_text, raw_payload
 from datapipeline.io.output import OutputTarget, output_destination_key
+from datapipeline.io.protocols import Writer
 from datapipeline.io.sinks.files import AtomicTextFileSink
 
 
@@ -105,13 +108,72 @@ def persist_artifact_output(
     return persisted
 
 
-def _close_runtime_rows(rows: Iterable[Any], logger: logging.Logger) -> None:
+def _close_runtime_rows(rows: Iterable[Any]) -> None:
     close = getattr(rows, "close", None)
     if callable(close):
+        close()
+
+
+@contextmanager
+def _runtime_rows(
+    rows: Iterable[Any],
+    logger: logging.Logger,
+) -> Iterator[Iterator[Any]]:
+    iterator: Iterator[Any] | None = None
+    failed = False
+    try:
+        iterator = iter(rows)
+        yield iterator
+    except BaseException:
+        failed = True
+        raise
+    finally:
         try:
-            close()
-        except Exception:
+            try:
+                if iterator is not None:
+                    _close_runtime_rows(iterator)
+            finally:
+                if iterator is not rows:
+                    _close_runtime_rows(rows)
+        except BaseException:
+            if not failed:
+                raise
             logger.debug("Failed to close runtime output rows", exc_info=True)
+
+
+def _payload_rows(result: RuntimeOutput, target: OutputTarget) -> Iterator[Any]:
+    if result.payload is None:
+        return iter(())
+    if target.format == "txt":
+        return iter((json_text(raw_payload(result.payload), indent=2),))
+    return iter((dict(result.payload),))
+
+
+def _write_html_output(
+    result: RuntimeOutput,
+    target: OutputTarget,
+    logger: logging.Logger,
+) -> None:
+    if result.render_html is None:
+        raise ValueError("html output is not supported for this operation.")
+    destination = target.destination
+    if destination is None:
+        raise ValueError("html output requires fs destination.")
+
+    sink = AtomicTextFileSink(
+        destination,
+        encoding=target.encoding or "utf-8",
+    )
+    try:
+        sink.write_text(result.render_html())
+        sink.close()
+    except BaseException:
+        try:
+            sink.abort()
+        except BaseException:
+            logger.debug("Failed to abort html output writer", exc_info=True)
+        raise
+    emit_file_result("Output", destination)
 
 
 def _persist_runtime_output(
@@ -121,60 +183,41 @@ def _persist_runtime_output(
     heartbeat_interval_seconds: float | None,
     logger: logging.Logger,
 ) -> None:
-    effective_target = result.target or target
-    if effective_target is None:
-        raise ValueError("Runtime operation requires profile output target.")
-
-    if effective_target.format == "html":
-        if result.render_html is None:
-            raise ValueError("html output is not supported for this operation.")
-        destination = effective_target.destination
-        if destination is None:
-            raise ValueError("html output requires fs destination.")
-        document = result.render_html()
-        sink = AtomicTextFileSink(
-            destination,
-            encoding=effective_target.encoding or "utf-8",
-        )
-        try:
-            sink.write_text(document)
-            sink.close()
-        except BaseException:
-            sink.abort()
-            raise
-        emit_file_result("Output", destination)
-        return
-
-    rows = result.rows
-    if rows is None:
-        if result.payload is None:
-            rows = ()
-        elif effective_target.format == "txt":
-            rows = (json_text(raw_payload(result.payload), indent=2),)
-        else:
-            rows = (dict(result.payload),)
-
-    writer = writer_factory(effective_target)
-    rows = iter(rows)
-    progress = OperationProgressTracker(
-        "write_output",
-        "rows",
-        resolve_heartbeat_interval_seconds(heartbeat_interval_seconds),
-    )
-    success = False
+    supplied_rows = result.rows
+    owned_rows = supplied_rows if supplied_rows is not None else ()
+    writer = None
     try:
-        for row in rows:
-            writer.write(row)
-            progress.advance()
+        with _runtime_rows(owned_rows, logger) as rows:
+            effective_target = result.target or target
+            if effective_target is None:
+                raise ValueError("Runtime operation requires profile output target.")
+
+            if effective_target.format != "html":
+                if supplied_rows is None:
+                    rows = _payload_rows(result, effective_target)
+                writer = writer_factory(effective_target)
+                progress = OperationProgressTracker(
+                    "write_output",
+                    "rows",
+                    resolve_heartbeat_interval_seconds(heartbeat_interval_seconds),
+                )
+                for row in rows:
+                    writer.write(row)
+                    progress.advance()
+
+        if effective_target.format == "html":
+            _write_html_output(result, effective_target, logger)
+            return
+
+        assert writer is not None
         writer.close()
-        success = True
-    finally:
-        _close_runtime_rows(rows, logger)
-        if not success:
+    except BaseException:
+        if writer is not None:
             try:
                 writer.abort()
-            except Exception:
+            except BaseException:
                 logger.debug("Failed to abort runtime output writer", exc_info=True)
+        raise
 
     if effective_target.destination is not None:
         emit_file_result("Output", effective_target.destination)
@@ -182,16 +225,13 @@ def _persist_runtime_output(
         logger.info("Output: stdout")
 
 
-def _persist_routed_runtime_output(
+def _planned_routed_targets(
     result: RoutedRuntimeOutput,
-    *,
-    heartbeat_interval_seconds: float | None,
-    logger: logging.Logger,
-) -> None:
+) -> list[tuple[str, OutputTarget, Path]]:
     if not result.targets:
         raise ValueError("Routed runtime output requires at least one target.")
 
-    planned_targets: list[tuple[str, OutputTarget, Path]] = []
+    planned: list[tuple[str, OutputTarget, Path]] = []
     destination_owners: dict[str, str] = {}
     for output_id, target in result.targets.items():
         destination = target.destination
@@ -205,63 +245,135 @@ def _persist_routed_runtime_output(
                 f"destination: {destination}"
             )
         destination_owners[destination_key] = output_id
-        planned_targets.append((output_id, target, destination))
+        planned.append((output_id, target, destination))
+    return planned
 
-    writers = {}
+
+def _route_runtime_rows(
+    result: RoutedRuntimeOutput,
+    rows: Iterator[Any],
+    writers: Mapping[str, Writer],
+    counts: dict[str, int],
+    progress: OperationProgressTracker,
+) -> None:
+    for row in rows:
+        routed_id = result.output_for_row(row)
+        if routed_id is None:
+            continue
+        writer = writers.get(routed_id)
+        if writer is None:
+            continue
+        if (
+            result.limit_per_output is not None
+            and counts[routed_id] >= result.limit_per_output
+        ):
+            if all(count >= result.limit_per_output for count in counts.values()):
+                break
+            continue
+        writer.write(row)
+        counts[routed_id] += 1
+        progress.advance()
+        if result.limit_per_output is not None and all(
+            count >= result.limit_per_output for count in counts.values()
+        ):
+            break
+
+
+def _persist_routed_runtime_output(
+    result: RoutedRuntimeOutput,
+    *,
+    heartbeat_interval_seconds: float | None,
+    logger: logging.Logger,
+) -> None:
+    writers: dict[str, Writer] = {}
     counts: dict[str, int] = {}
     destinations: dict[str, Path] = {}
-    rows = iter(result.rows)
-    progress = OperationProgressTracker(
-        "write_output",
-        "rows",
-        resolve_heartbeat_interval_seconds(heartbeat_interval_seconds),
-    )
-    success = False
     try:
-        for output_id, target, destination in planned_targets:
-            writers[output_id] = writer_factory(target)
-            counts[output_id] = 0
-            destinations[output_id] = destination
+        with _runtime_rows(result.rows, logger) as rows:
+            for output_id, target, destination in _planned_routed_targets(result):
+                writers[output_id] = writer_factory(target)
+                counts[output_id] = 0
+                destinations[output_id] = destination
 
-        for row in rows:
-            routed_id = result.output_for_row(row)
-            if routed_id is None:
-                continue
-            writer = writers.get(routed_id)
-            if writer is None:
-                continue
-            if (
-                result.limit_per_output is not None
-                and counts[routed_id] >= result.limit_per_output
-            ):
-                if all(count >= result.limit_per_output for count in counts.values()):
-                    break
-                continue
-            writer.write(row)
-            counts[routed_id] += 1
-            progress.advance()
-            if result.limit_per_output is not None and all(
-                count >= result.limit_per_output for count in counts.values()
-            ):
-                break
+            progress = OperationProgressTracker(
+                "write_output",
+                "rows",
+                resolve_heartbeat_interval_seconds(heartbeat_interval_seconds),
+            )
+            _route_runtime_rows(result, rows, writers, counts, progress)
 
         for writer in writers.values():
             writer.close()
-        success = True
-    finally:
-        _close_runtime_rows(rows, logger)
-        if not success:
-            for writer in writers.values():
-                try:
-                    writer.abort()
-                except Exception:
-                    logger.debug(
-                        "Failed to abort routed runtime output writer",
-                        exc_info=True,
-                    )
+    except BaseException:
+        for writer in writers.values():
+            try:
+                writer.abort()
+            except BaseException:
+                logger.debug(
+                    "Failed to abort routed runtime output writer",
+                    exc_info=True,
+                )
+        raise
 
     for output_id, destination in destinations.items():
         emit_file_result(output_id, destination)
+
+
+def _close_pending_runtime_outputs(
+    outputs: Sequence[RuntimeOutput | RoutedRuntimeOutput],
+    logger: logging.Logger,
+) -> None:
+    for output in outputs:
+        if output.rows is None:
+            continue
+        try:
+            _close_runtime_rows(output.rows)
+        except BaseException:
+            logger.debug(
+                "Failed to close pending runtime output rows",
+                exc_info=True,
+            )
+
+
+def _persist_runtime_batch(
+    result: RuntimeOutputBatch,
+    target: OutputTarget | None,
+    heartbeat_interval_seconds: float | None,
+    logger: logging.Logger,
+) -> None:
+    success = False
+    attempted = 0
+    try:
+        for output in result.outputs:
+            attempted += 1
+            if isinstance(output, RoutedRuntimeOutput):
+                _persist_routed_runtime_output(
+                    output,
+                    heartbeat_interval_seconds=heartbeat_interval_seconds,
+                    logger=logger,
+                )
+            else:
+                _persist_runtime_output(
+                    output,
+                    target=target,
+                    heartbeat_interval_seconds=heartbeat_interval_seconds,
+                    logger=logger,
+                )
+        success = True
+    finally:
+        if not success:
+            _close_pending_runtime_outputs(result.outputs[attempted:], logger)
+        if result.on_complete is not None:
+            try:
+                result.on_complete(success)
+            except BaseException:
+                if success:
+                    raise
+                logger.debug(
+                    "Runtime output completion callback failed after an earlier "
+                    "persistence failure",
+                    exc_info=True,
+                )
 
 
 def persist_runtime_result(
@@ -279,26 +391,12 @@ def persist_runtime_result(
             "RuntimeOutputBatch, or None."
         )
     if isinstance(result, RuntimeOutputBatch):
-        success = False
-        try:
-            for output in result.outputs:
-                if isinstance(output, RoutedRuntimeOutput):
-                    _persist_routed_runtime_output(
-                        output,
-                        heartbeat_interval_seconds=heartbeat_interval_seconds,
-                        logger=logger,
-                    )
-                else:
-                    _persist_runtime_output(
-                        output,
-                        target=target,
-                        heartbeat_interval_seconds=heartbeat_interval_seconds,
-                        logger=logger,
-                    )
-            success = True
-        finally:
-            if result.on_complete is not None:
-                result.on_complete(success)
+        _persist_runtime_batch(
+            result,
+            target,
+            heartbeat_interval_seconds,
+            logger,
+        )
         return
 
     if isinstance(result, RoutedRuntimeOutput):

--- a/src/datapipeline/profiles/orchestration.py
+++ b/src/datapipeline/profiles/orchestration.py
@@ -231,13 +231,28 @@ def _validate_build_order(jobs: list[BuildJob], graph: ArtifactGraph) -> None:
 
 
 def _finalize_serve_runs(plans: list[ServeRunPlan], succeeded: bool) -> None:
+    if not succeeded:
+        for plan in plans:
+            try:
+                finish_run_failed(plan.paths)
+            except Exception:
+                logger.exception(
+                    "Failed to finalize serve run '%s' after command failure.",
+                    plan.paths.run_id,
+                )
+        return
+
+    first_error: Exception | None = None
     for plan in plans:
-        if not succeeded:
-            finish_run_failed(plan.paths)
-            continue
-        finish_run_success(plan.paths)
-        if plan.preview is None:
-            set_latest_run(plan.paths)
+        try:
+            finish_run_success(plan.paths)
+            if plan.preview is None:
+                set_latest_run(plan.paths)
+        except Exception as exc:
+            if first_error is None:
+                first_error = exc
+    if first_error is not None:
+        raise first_error
 
 
 def _prepare_runtime_artifacts(

--- a/src/datapipeline/profiles/orchestration.py
+++ b/src/datapipeline/profiles/orchestration.py
@@ -251,6 +251,12 @@ def _finalize_serve_runs(plans: list[ServeRunPlan], succeeded: bool) -> None:
         except Exception as exc:
             if first_error is None:
                 first_error = exc
+            else:
+                logger.exception(
+                    "Failed to finalize serve run '%s' after an earlier "
+                    "finalization failure.",
+                    plan.paths.run_id,
+                )
     if first_error is not None:
         raise first_error
 

--- a/src/datapipeline/profiles/request_builder.py
+++ b/src/datapipeline/profiles/request_builder.py
@@ -61,7 +61,8 @@ def _validation_error_without_inputs(exc: ValidationError) -> str:
     details = []
     for error in exc.errors(include_input=False, include_url=False):
         location = ".".join(str(part) for part in error["loc"]) or exc.title
-        details.append(f"{location}\n  {error['msg']} [type={error['type']}]")
+        message = "Invalid configuration value" if error.get("ctx") else error["msg"]
+        details.append(f"{location}\n  {message} [type={error['type']}]")
     return "\n".join((heading, *details))
 
 

--- a/src/datapipeline/profiles/request_builder.py
+++ b/src/datapipeline/profiles/request_builder.py
@@ -4,6 +4,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Literal, Sequence
 
+from pydantic import ValidationError
+
 from datapipeline.artifacts.settings import BuildSettings
 from datapipeline.config.preview import PreviewStage
 from datapipeline.config.profiles import (
@@ -53,6 +55,16 @@ from datapipeline.services.runtime_compiler import compile_runtime
 logger = logging.getLogger(__name__)
 
 
+def _validation_error_without_inputs(exc: ValidationError) -> str:
+    count = exc.error_count()
+    heading = f"{count} validation error{'s' if count != 1 else ''} for {exc.title}"
+    details = []
+    for error in exc.errors(include_input=False, include_url=False):
+        location = ".".join(str(part) for part in error["loc"]) or exc.title
+        details.append(f"{location}\n  {error['msg']} [type={error['type']}]")
+    return "\n".join((heading, *details))
+
+
 def _execution_root(artifacts_root: Path) -> Path:
     execution_id = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H-%M-%S-%fZ")
     return (artifacts_root / "_system" / "executions" / execution_id).resolve()
@@ -61,6 +73,12 @@ def _execution_root(artifacts_root: Path) -> Path:
 def _load_definition(project: str) -> PipelineDefinition:
     try:
         return load_pipeline(Path(project))
+    except ValidationError as exc:
+        logger.error(
+            "Failed to load pipeline inputs: %s",
+            _validation_error_without_inputs(exc),
+        )
+        raise SystemExit(2) from exc
     except (OSError, RuntimeError, TypeError, ValueError) as exc:
         logger.error("Failed to load pipeline inputs: %s", exc)
         raise SystemExit(2) from exc
@@ -76,6 +94,13 @@ def _select_profiles(
             project,
             cmd=command,
         )
+    except ValidationError as exc:
+        logger.error(
+            "Failed to load %s profiles: %s",
+            command,
+            _validation_error_without_inputs(exc),
+        )
+        raise SystemExit(2) from exc
     except (OSError, TypeError, ValueError) as exc:
         logger.error("Failed to load %s profiles: %s", command, exc)
         raise SystemExit(2) from exc
@@ -98,6 +123,9 @@ def _select_profiles(
             [apply_profile_defaults(profile, defaults) for profile in selected],
             defaults,
         )
+    except ValidationError as exc:
+        logger.error("%s", _validation_error_without_inputs(exc))
+        raise SystemExit(2) from exc
     except ValueError as exc:
         logger.error("%s", exc)
         raise SystemExit(2) from exc

--- a/src/datapipeline/services/execution_lock.py
+++ b/src/datapipeline/services/execution_lock.py
@@ -1,5 +1,6 @@
 import errno
 import sys
+import time
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
@@ -44,6 +45,20 @@ else:
 
 class ProjectExecutionBusyError(RuntimeError):
     pass
+
+
+@contextmanager
+def exclusive_file_lock(path: Path) -> Iterator[None]:
+    """Wait for exclusive access to a stable lock file."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a+b") as lock_file:
+        while not try_acquire_file_lock(lock_file):
+            time.sleep(0.01)
+        try:
+            yield
+        finally:
+            release_file_lock(lock_file)
 
 
 @contextmanager

--- a/src/datapipeline/services/scaffold/domain.py
+++ b/src/datapipeline/services/scaffold/domain.py
@@ -5,6 +5,7 @@ from datapipeline.services.scaffold.layout import (
     TPL_DOMAIN_RECORD,
     domain_record_class,
 )
+from datapipeline.services.scaffold.locking import ScaffoldLock, acquire_scaffold_lock
 from datapipeline.services.scaffold.paths import (
     ensure_base_pkg_dir,
     pkg_root,
@@ -14,37 +15,49 @@ from datapipeline.services.scaffold.templates import render
 from datapipeline.services.scaffold.utils import (
     ensure_pkg_dir,
     is_python_identifier,
+    rollback_new_scaffold_paths,
     write_new_file,
 )
+
+
+def domain_scaffold_paths(domain: str, root: Path | None) -> tuple[Path, ...]:
+    root_dir, name, _ = pkg_root(root)
+    base = resolve_base_pkg_dir(root_dir, name)
+    domain_dir = base / DIR_DOMAINS / domain
+    return base / "__init__.py", domain_dir / "__init__.py", domain_dir / "model.py"
 
 
 def validate_domain_creation(domain: str, root: Path | None) -> None:
     if not is_python_identifier(domain):
         raise ValueError("Domain name must be a valid Python identifier")
-    root_dir, name, _ = pkg_root(root)
-    base = resolve_base_pkg_dir(root_dir, name)
-    path = base / DIR_DOMAINS / domain / "model.py"
+    path = domain_scaffold_paths(domain, root)[-1]
     if path.exists():
         raise FileExistsError(f"{path} already exists")
 
 
-def create_domain(domain: str, root: Path | None) -> Path:
-    validate_domain_creation(domain, root)
-    root_dir, name, _ = pkg_root(root)
-    base = ensure_base_pkg_dir(root_dir, name)
-    package_name = base.name
-    pkg_dir = ensure_pkg_dir(base / DIR_DOMAINS, domain)
-    parent = "TemporalRecord"
-    path = pkg_dir / "model.py"
-    write_new_file(
-        path,
-        render(
-            TPL_DOMAIN_RECORD,
-            PACKAGE_NAME=package_name,
-            DOMAIN=domain,
-            CLASS_NAME=domain_record_class(domain),
-            PARENT_CLASS=parent,
-            time_aware=True,
-        ),
-    )
-    return path
+def create_domain(
+    domain: str,
+    root: Path | None,
+    scaffold_lock: ScaffoldLock | None = None,
+) -> Path:
+    root_dir, name, pyproject = pkg_root(root)
+    with acquire_scaffold_lock(pyproject.parent, scaffold_lock):
+        validate_domain_creation(domain, root)
+        created_paths = domain_scaffold_paths(domain, root)
+        with rollback_new_scaffold_paths(created_paths):
+            base = ensure_base_pkg_dir(root_dir, name)
+            package_name = base.name
+            pkg_dir = ensure_pkg_dir(base / DIR_DOMAINS, domain)
+            path = pkg_dir / "model.py"
+            write_new_file(
+                path,
+                render(
+                    TPL_DOMAIN_RECORD,
+                    PACKAGE_NAME=package_name,
+                    DOMAIN=domain,
+                    CLASS_NAME=domain_record_class(domain),
+                    PARENT_CLASS="TemporalRecord",
+                    time_aware=True,
+                ),
+            )
+            return path

--- a/src/datapipeline/services/scaffold/dto.py
+++ b/src/datapipeline/services/scaffold/dto.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 from datapipeline.services.scaffold.layout import DIR_DTOS, TPL_DTO, to_snake
+from datapipeline.services.scaffold.locking import ScaffoldLock, acquire_scaffold_lock
 from datapipeline.services.scaffold.paths import (
     ensure_base_pkg_dir,
     pkg_root,
@@ -10,33 +11,49 @@ from datapipeline.services.scaffold.templates import render
 from datapipeline.services.scaffold.utils import (
     ensure_pkg_dir,
     is_python_identifier,
+    rollback_new_scaffold_paths,
     write_new_file,
 )
+
+
+def dto_scaffold_paths(name: str, root: Path | None) -> tuple[Path, ...]:
+    root_dir, pkg_name, _ = pkg_root(root)
+    base = resolve_base_pkg_dir(root_dir, pkg_name)
+    dtos_dir = base / DIR_DTOS
+    return (
+        base / "__init__.py",
+        dtos_dir / "__init__.py",
+        dtos_dir / f"{to_snake(name)}.py",
+    )
 
 
 def validate_dto_creation(name: str, root: Path | None) -> None:
     if not is_python_identifier(name):
         raise ValueError("DTO name must be a valid Python identifier")
-    root_dir, pkg_name, _ = pkg_root(root)
-    base = resolve_base_pkg_dir(root_dir, pkg_name)
-    path = base / DIR_DTOS / f"{to_snake(name)}.py"
+    path = dto_scaffold_paths(name, root)[-1]
     if path.exists():
         raise FileExistsError(f"{path} already exists")
 
 
-def create_dto(name: str, root: Path | None) -> Path:
-    validate_dto_creation(name, root)
-    root_dir, pkg_name, _ = pkg_root(root)
-    base = ensure_base_pkg_dir(root_dir, pkg_name)
-    dtos_dir = ensure_pkg_dir(base, DIR_DTOS)
-    module_name = to_snake(name)
-    path = dtos_dir / f"{module_name}.py"
-    write_new_file(
-        path,
-        render(
-            TPL_DTO,
-            CLASS_NAME=name,
-            DOMAIN=name,
-        ),
-    )
-    return path
+def create_dto(
+    name: str,
+    root: Path | None,
+    scaffold_lock: ScaffoldLock | None = None,
+) -> Path:
+    root_dir, pkg_name, pyproject = pkg_root(root)
+    with acquire_scaffold_lock(pyproject.parent, scaffold_lock):
+        validate_dto_creation(name, root)
+        created_paths = dto_scaffold_paths(name, root)
+        with rollback_new_scaffold_paths(created_paths):
+            base = ensure_base_pkg_dir(root_dir, pkg_name)
+            dtos_dir = ensure_pkg_dir(base, DIR_DTOS)
+            path = dtos_dir / f"{to_snake(name)}.py"
+            write_new_file(
+                path,
+                render(
+                    TPL_DTO,
+                    CLASS_NAME=name,
+                    DOMAIN=name,
+                ),
+            )
+            return path

--- a/src/datapipeline/services/scaffold/entrypoints.py
+++ b/src/datapipeline/services/scaffold/entrypoints.py
@@ -5,6 +5,10 @@ from tomlkit.items import AbstractTable, InlineTable
 from tomlkit.toml_document import TOMLDocument
 
 from datapipeline.io.sinks.files import AtomicTextFileSink
+from datapipeline.services.scaffold.locking import (
+    ScaffoldLock,
+    acquire_scaffold_lock,
+)
 
 
 def _write_document(pyproject: Path, document: TOMLDocument, original: str) -> None:
@@ -21,7 +25,7 @@ def _write_document(pyproject: Path, document: TOMLDocument, original: str) -> N
         raise
 
 
-def register_entry_point(
+def _register_entry_point(
     pyproject: Path,
     group: str,
     key: str,
@@ -88,6 +92,18 @@ def register_entry_point(
         entries[key] = target
     _write_document(pyproject, document, original)
     return True
+
+
+def register_entry_point(
+    pyproject: Path,
+    group: str,
+    key: str,
+    target: str,
+    scaffold_lock: ScaffoldLock | None = None,
+) -> bool:
+    resolved = pyproject.resolve()
+    with acquire_scaffold_lock(resolved.parent, scaffold_lock):
+        return _register_entry_point(resolved, group, key, target)
 
 
 def read_entry_points(pyproject: Path, group: str) -> dict[str, str]:

--- a/src/datapipeline/services/scaffold/loader.py
+++ b/src/datapipeline/services/scaffold/loader.py
@@ -12,6 +12,7 @@ from datapipeline.services.scaffold.layout import (
     loader_class_name,
     to_snake,
 )
+from datapipeline.services.scaffold.locking import ScaffoldLock, acquire_scaffold_lock
 from datapipeline.services.scaffold.paths import (
     ensure_base_pkg_dir,
     pkg_root,
@@ -21,19 +22,30 @@ from datapipeline.services.scaffold.templates import render
 from datapipeline.services.scaffold.utils import (
     ensure_pkg_dir,
     is_python_identifier,
+    rollback_new_scaffold_paths,
     write_new_file,
 )
+
+
+def loader_scaffold_paths(name: str, root: Path | None) -> tuple[Path, ...]:
+    root_dir, pkg_name, _ = pkg_root(root)
+    base = resolve_base_pkg_dir(root_dir, pkg_name)
+    loaders_dir = base / DIR_LOADERS
+    return (
+        base / "__init__.py",
+        loaders_dir / "__init__.py",
+        loaders_dir / f"{to_snake(name)}.py",
+    )
 
 
 def validate_loader_creation(name: str, root: Path | None) -> None:
     if not is_python_identifier(name):
         raise ValueError("Loader name must be a valid Python identifier")
-    root_dir, pkg_name, pyproject = pkg_root(root)
+    _, _, pyproject = pkg_root(root)
     entrypoint = ep_key_from_name(name)
     if entrypoint in read_entry_points(pyproject, LOADERS_EP):
         raise FileExistsError(f"Loader entry point '{entrypoint}' already exists")
-    base = resolve_base_pkg_dir(root_dir, pkg_name)
-    path = base / DIR_LOADERS / f"{to_snake(name)}.py"
+    path = loader_scaffold_paths(name, root)[-1]
     if path.exists():
         raise FileExistsError(f"{path} already exists")
 
@@ -41,31 +53,27 @@ def validate_loader_creation(name: str, root: Path | None) -> None:
 def create_loader(
     name: str,
     root: Path | None,
+    scaffold_lock: ScaffoldLock | None = None,
 ) -> str:
-    validate_loader_creation(name, root)
     root_dir, pkg_name, pyproject = pkg_root(root)
-    base = ensure_base_pkg_dir(root_dir, pkg_name)
-    package_name = base.name
-
-    loaders_dir = ensure_pkg_dir(base, DIR_LOADERS)
-    module_name = to_snake(name)
-    path = loaders_dir / f"{module_name}.py"
-
-    class_name = loader_class_name(name)
-
-    write_new_file(
-        path,
-        render(
-            TPL_LOADER_BASIC,
-            CLASS_NAME=class_name,
-        ),
-    )
-
-    ep_key = ep_key_from_name(name)
-    register_entry_point(
-        pyproject,
-        LOADERS_EP,
-        ep_key,
-        f"{package_name}.loaders.{module_name}:{class_name}",
-    )
-    return ep_key
+    with acquire_scaffold_lock(pyproject.parent, scaffold_lock) as lock:
+        validate_loader_creation(name, root)
+        created_paths = loader_scaffold_paths(name, root)
+        base = created_paths[0].parent
+        path = created_paths[-1]
+        module_name = path.stem
+        class_name = loader_class_name(name)
+        content = render(TPL_LOADER_BASIC, CLASS_NAME=class_name)
+        with rollback_new_scaffold_paths(created_paths):
+            ensure_base_pkg_dir(root_dir, pkg_name)
+            ensure_pkg_dir(base, DIR_LOADERS)
+            write_new_file(path, content)
+            ep_key = ep_key_from_name(name)
+            register_entry_point(
+                pyproject,
+                LOADERS_EP,
+                ep_key,
+                f"{base.name}.loaders.{module_name}:{class_name}",
+                scaffold_lock=lock,
+            )
+            return ep_key

--- a/src/datapipeline/services/scaffold/locking.py
+++ b/src/datapipeline/services/scaffold/locking.py
@@ -1,0 +1,41 @@
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+from datapipeline.services.execution_lock import exclusive_file_lock
+
+_LOCK_FILE = ".jerry-scaffold.lock"
+
+
+class ScaffoldLock:
+    def __init__(self, path: Path):
+        self.path = path
+        self._active = True
+
+    def _release(self) -> None:
+        self._active = False
+
+    def _require_active(self) -> None:
+        if not self._active:
+            raise RuntimeError("Scaffold lock is no longer active")
+
+
+@contextmanager
+def acquire_scaffold_lock(
+    directory: Path,
+    held_lock: ScaffoldLock | None = None,
+) -> Iterator[ScaffoldLock]:
+    """Serialize scaffold mutations owned by one directory."""
+
+    path = directory.resolve() / _LOCK_FILE
+    if held_lock is not None and held_lock.path == path:
+        held_lock._require_active()
+        yield held_lock
+        return
+
+    with exclusive_file_lock(path):
+        lock = ScaffoldLock(path)
+        try:
+            yield lock
+        finally:
+            lock._release()

--- a/src/datapipeline/services/scaffold/mapper.py
+++ b/src/datapipeline/services/scaffold/mapper.py
@@ -12,6 +12,7 @@ from datapipeline.services.scaffold.layout import (
     ep_key_from_name,
     to_snake,
 )
+from datapipeline.services.scaffold.locking import ScaffoldLock, acquire_scaffold_lock
 from datapipeline.services.scaffold.paths import (
     ensure_base_pkg_dir,
     pkg_root,
@@ -21,19 +22,30 @@ from datapipeline.services.scaffold.templates import render
 from datapipeline.services.scaffold.utils import (
     ensure_pkg_dir,
     is_python_identifier,
+    rollback_new_scaffold_paths,
     write_new_file,
 )
+
+
+def mapper_scaffold_paths(name: str, root: Path | None) -> tuple[Path, ...]:
+    root_dir, pkg_name, _ = pkg_root(root)
+    base = resolve_base_pkg_dir(root_dir, pkg_name)
+    mappers_dir = base / DIR_MAPPERS
+    return (
+        base / "__init__.py",
+        mappers_dir / "__init__.py",
+        mappers_dir / f"{to_snake(name)}.py",
+    )
 
 
 def validate_mapper_creation(name: str, root: Path | None) -> None:
     if not is_python_identifier(name):
         raise ValueError("Mapper name must be a valid Python identifier")
-    root_dir, pkg_name, pyproject = pkg_root(root)
+    _, _, pyproject = pkg_root(root)
     entrypoint = ep_key_from_name(name)
     if entrypoint in read_entry_points(pyproject, MAPPERS_EP):
         raise FileExistsError(f"Mapper entry point '{entrypoint}' already exists")
-    base = resolve_base_pkg_dir(root_dir, pkg_name)
-    path = base / DIR_MAPPERS / f"{to_snake(name)}.py"
+    path = mapper_scaffold_paths(name, root)[-1]
     if path.exists():
         raise FileExistsError(f"{path} already exists")
 
@@ -45,36 +57,33 @@ def create_mapper(
     input_module: str,
     domain: str,
     root: Path | None,
+    scaffold_lock: ScaffoldLock | None = None,
 ) -> str:
-    validate_mapper_creation(name, root)
     root_dir, pkg_name, pyproject = pkg_root(root)
-    base = ensure_base_pkg_dir(root_dir, pkg_name)
-    package_name = base.name
-
-    mappers_dir = ensure_pkg_dir(base, DIR_MAPPERS)
-    module_name = to_snake(name)
-    path = mappers_dir / f"{module_name}.py"
-
-    domain_module = f"{package_name}.domains.{domain}.model"
-    domain_record = domain_record_class(domain)
-
-    write_new_file(
-        path,
-        render(
+    with acquire_scaffold_lock(pyproject.parent, scaffold_lock) as lock:
+        validate_mapper_creation(name, root)
+        created_paths = mapper_scaffold_paths(name, root)
+        base = created_paths[0].parent
+        path = created_paths[-1]
+        module_name = path.stem
+        content = render(
             TPL_MAPPER_SOURCE,
             FUNCTION_NAME=module_name,
             INPUT_CLASS=input_class,
             INPUT_IMPORT=input_module,
-            DOMAIN_MODULE=domain_module,
-            DOMAIN_RECORD=domain_record,
-        ),
-    )
-
-    ep_key = ep_key_from_name(name)
-    register_entry_point(
-        pyproject,
-        MAPPERS_EP,
-        ep_key,
-        f"{package_name}.mappers.{module_name}:{module_name}",
-    )
-    return ep_key
+            DOMAIN_MODULE=f"{base.name}.domains.{domain}.model",
+            DOMAIN_RECORD=domain_record_class(domain),
+        )
+        with rollback_new_scaffold_paths(created_paths):
+            ensure_base_pkg_dir(root_dir, pkg_name)
+            ensure_pkg_dir(base, DIR_MAPPERS)
+            write_new_file(path, content)
+            ep_key = ep_key_from_name(name)
+            register_entry_point(
+                pyproject,
+                MAPPERS_EP,
+                ep_key,
+                f"{base.name}.mappers.{module_name}:{module_name}",
+                scaffold_lock=lock,
+            )
+            return ep_key

--- a/src/datapipeline/services/scaffold/parser.py
+++ b/src/datapipeline/services/scaffold/parser.py
@@ -11,6 +11,7 @@ from datapipeline.services.scaffold.layout import (
     ep_key_from_name,
     to_snake,
 )
+from datapipeline.services.scaffold.locking import ScaffoldLock, acquire_scaffold_lock
 from datapipeline.services.scaffold.paths import (
     ensure_base_pkg_dir,
     pkg_root,
@@ -20,19 +21,30 @@ from datapipeline.services.scaffold.templates import render
 from datapipeline.services.scaffold.utils import (
     ensure_pkg_dir,
     is_python_identifier,
+    rollback_new_scaffold_paths,
     write_new_file,
 )
+
+
+def parser_scaffold_paths(name: str, root: Path | None) -> tuple[Path, ...]:
+    root_dir, pkg_name, _ = pkg_root(root)
+    base = resolve_base_pkg_dir(root_dir, pkg_name)
+    parsers_dir = base / DIR_PARSERS
+    return (
+        base / "__init__.py",
+        parsers_dir / "__init__.py",
+        parsers_dir / f"{to_snake(name)}.py",
+    )
 
 
 def validate_parser_creation(name: str, root: Path | None) -> None:
     if not is_python_identifier(name):
         raise ValueError("Parser name must be a valid Python identifier")
-    root_dir, pkg_name, pyproject = pkg_root(root)
+    _, _, pyproject = pkg_root(root)
     entrypoint = ep_key_from_name(name)
     if entrypoint in read_entry_points(pyproject, PARSERS_EP):
         raise FileExistsError(f"Parser entry point '{entrypoint}' already exists")
-    base = resolve_base_pkg_dir(root_dir, pkg_name)
-    path = base / DIR_PARSERS / f"{to_snake(name)}.py"
+    path = parser_scaffold_paths(name, root)[-1]
     if path.exists():
         raise FileExistsError(f"{path} already exists")
 
@@ -43,31 +55,31 @@ def create_parser(
     dto_class: str,
     dto_module: str,
     root: Path | None,
+    scaffold_lock: ScaffoldLock | None = None,
 ) -> str:
-    validate_parser_creation(name, root)
     root_dir, pkg_name, pyproject = pkg_root(root)
-    base = ensure_base_pkg_dir(root_dir, pkg_name)
-    package_name = base.name
-
-    parsers_dir = ensure_pkg_dir(base, DIR_PARSERS)
-    module_name = to_snake(name)
-    path = parsers_dir / f"{module_name}.py"
-
-    write_new_file(
-        path,
-        render(
+    with acquire_scaffold_lock(pyproject.parent, scaffold_lock) as lock:
+        validate_parser_creation(name, root)
+        created_paths = parser_scaffold_paths(name, root)
+        base = created_paths[0].parent
+        path = created_paths[-1]
+        module_name = path.stem
+        content = render(
             TPL_PARSER,
             CLASS_NAME=name,
             DTO_CLASS=dto_class,
             DTO_IMPORT=dto_module,
-        ),
-    )
-
-    ep_key = ep_key_from_name(name)
-    register_entry_point(
-        pyproject,
-        PARSERS_EP,
-        ep_key,
-        f"{package_name}.parsers.{module_name}:{name}",
-    )
-    return ep_key
+        )
+        with rollback_new_scaffold_paths(created_paths):
+            ensure_base_pkg_dir(root_dir, pkg_name)
+            ensure_pkg_dir(base, DIR_PARSERS)
+            write_new_file(path, content)
+            ep_key = ep_key_from_name(name)
+            register_entry_point(
+                pyproject,
+                PARSERS_EP,
+                ep_key,
+                f"{base.name}.parsers.{module_name}:{name}",
+                scaffold_lock=lock,
+            )
+            return ep_key

--- a/src/datapipeline/services/scaffold/paths.py
+++ b/src/datapipeline/services/scaffold/paths.py
@@ -4,6 +4,8 @@ from pathlib import Path
 from datapipeline.services.definitions import ProjectManifest
 from datapipeline.services.path_policy import workspace_cwd
 from datapipeline.services.project import load_project
+from datapipeline.services.scaffold.locking import ScaffoldLock, acquire_scaffold_lock
+from datapipeline.services.scaffold.utils import write_new_file
 
 _DEFAULT_DOTENV_EXAMPLE = (
     "# Copy this file to .env next to project.yaml for local dataset-specific secrets.\n"
@@ -60,36 +62,40 @@ def default_project_yaml_path(plugin_root: Path) -> Path:
     return plugin_root / "your-dataset" / "project.yaml"
 
 
-def ensure_project_scaffold(project_yaml: Path) -> ProjectManifest:
+def ensure_project_scaffold(
+    project_yaml: Path,
+    scaffold_lock: ScaffoldLock | None = None,
+) -> ProjectManifest:
     """Create a minimal project and its configured directories when absent."""
-    if not project_yaml.exists():
-        project_yaml.parent.mkdir(parents=True, exist_ok=True)
-        project_yaml.write_text(
-            "schema_version: 2\n"
-            "artifact_revision: 1\n"
-            "name: default\n"
-            "paths:\n"
-            "  streams: ./streams\n"
-            "  sources: ./sources\n"
-            "  dataset: dataset.yaml\n"
-            "  artifacts: ../artifacts/default\n"
-            "  profiles: ./profiles\n"
-            "globals:\n"
-            "  start_time: 2021-01-01T00:00:00Z\n"
-            "  end_time: 2021-12-31T23:00:00Z\n",
-            encoding="utf-8",
-        )
+    with acquire_scaffold_lock(project_yaml.parent, scaffold_lock):
+        if not project_yaml.exists():
+            project_yaml.parent.mkdir(parents=True, exist_ok=True)
+            write_new_file(
+                project_yaml,
+                "schema_version: 2\n"
+                "artifact_revision: 1\n"
+                "name: default\n"
+                "paths:\n"
+                "  streams: ./streams\n"
+                "  sources: ./sources\n"
+                "  dataset: dataset.yaml\n"
+                "  artifacts: ../artifacts/default\n"
+                "  profiles: ./profiles\n"
+                "globals:\n"
+                "  start_time: 2021-01-01T00:00:00Z\n"
+                "  end_time: 2021-12-31T23:00:00Z\n",
+            )
 
-    project = load_project(project_yaml)
-    for streams in project.stream_dirs:
-        streams.mkdir(parents=True, exist_ok=True)
-    for sources in project.source_dirs:
-        sources.mkdir(parents=True, exist_ok=True)
-    if project.operations_dir is not None:
-        project.operations_dir.mkdir(parents=True, exist_ok=True)
-    project.profiles_dir.mkdir(parents=True, exist_ok=True)
+        project = load_project(project_yaml)
+        for streams in project.stream_dirs:
+            streams.mkdir(parents=True, exist_ok=True)
+        for sources in project.source_dirs:
+            sources.mkdir(parents=True, exist_ok=True)
+        if project.operations_dir is not None:
+            project.operations_dir.mkdir(parents=True, exist_ok=True)
+        project.profiles_dir.mkdir(parents=True, exist_ok=True)
 
-    dotenv_example = project_yaml.parent / ".env.example"
-    if not dotenv_example.exists():
-        dotenv_example.write_text(_DEFAULT_DOTENV_EXAMPLE, encoding="utf-8")
-    return project
+        dotenv_example = project_yaml.parent / ".env.example"
+        if not dotenv_example.exists():
+            write_new_file(dotenv_example, _DEFAULT_DOTENV_EXAMPLE)
+        return project

--- a/src/datapipeline/services/scaffold/source_yaml.py
+++ b/src/datapipeline/services/scaffold/source_yaml.py
@@ -2,6 +2,7 @@ import re
 from pathlib import Path
 
 from datapipeline.services.project import load_project
+from datapipeline.services.scaffold.locking import ScaffoldLock, acquire_scaffold_lock
 from datapipeline.services.scaffold.paths import (
     default_project_yaml_path,
     ensure_project_scaffold,
@@ -9,6 +10,7 @@ from datapipeline.services.scaffold.paths import (
 )
 from datapipeline.services.scaffold.templates import render
 from datapipeline.services.scaffold.utils import write_new_file
+from datapipeline.services.streams.loader import declared_source_ids
 
 DEFAULT_IO_LOADER_EP = "core.io"
 DEFAULT_SYNTHETIC_LOADER_EP = "core.synthetic.ticks"
@@ -21,12 +23,15 @@ def _loader_args(transport: str, fmt: str | None) -> dict[str, object]:
             "transport": "fs",
             "format": fmt or "<FORMAT (csv|json|jsonl|pickle)>",
             "path": "<PATH OR GLOB>",
-            "encoding": "utf-8",
         }
+        if fmt != "pickle":
+            args["encoding"] = "utf-8"
         if fmt == "csv":
             args["delimiter"] = ","
         return args
     if transport == "http":
+        if fmt == "pickle":
+            raise ValueError("Source format 'pickle' is not supported for http")
         args = {
             "transport": "http",
             "format": fmt or "<FORMAT (json|jsonl|csv)>",
@@ -67,38 +72,39 @@ def create_source_yaml(
     parser_args: dict[str, object] | None = None,
     root: Path | None,
     project_yaml: Path | None = None,
+    scaffold_lock: ScaffoldLock | None = None,
 ) -> Path:
     root_dir, _, _ = pkg_root(root)
-    validate_source_id(source_id)
-    parser_args = parser_args or {}
-
     proj_yaml = (
         project_yaml.resolve()
         if project_yaml is not None
         else default_project_yaml_path(root_dir)
     )
-    if proj_yaml.exists():
-        project = load_project(proj_yaml)
-        existing_path = project.source_dirs[0] / f"{source_id}.yaml"
-        if existing_path.exists():
-            raise FileExistsError(f"{existing_path} already exists")
-    project = ensure_project_scaffold(proj_yaml)
-    sources_dir = project.source_dirs[0]
-
-    src_cfg_path = sources_dir / f"{source_id}.yaml"
-    write_new_file(
-        src_cfg_path,
-        render(
-            "source.yaml.j2",
-            id=source_id,
-            parser_ep=parser_ep,
-            parser_args=parser_args,
-            loader_ep=loader_ep,
-            loader_args=loader_args,
-            default_io_loader_ep=DEFAULT_IO_LOADER_EP,
-        ),
-    )
-    return src_cfg_path.resolve()
+    with acquire_scaffold_lock(proj_yaml.parent, scaffold_lock) as project_lock:
+        validate_source_id(source_id)
+        parser_args = parser_args or {}
+        if proj_yaml.exists():
+            project = load_project(proj_yaml)
+            existing_path = project.source_dirs[0] / f"{source_id}.yaml"
+            if existing_path.exists():
+                raise FileExistsError(f"{existing_path} already exists")
+        project = ensure_project_scaffold(proj_yaml, project_lock)
+        if source_id in declared_source_ids(project):
+            raise FileExistsError(f"Source id '{source_id}' already exists")
+        src_cfg_path = project.source_dirs[0] / f"{source_id}.yaml"
+        write_new_file(
+            src_cfg_path,
+            render(
+                "source.yaml.j2",
+                id=source_id,
+                parser_ep=parser_ep,
+                parser_args=parser_args,
+                loader_ep=loader_ep,
+                loader_args=loader_args,
+                default_io_loader_ep=DEFAULT_IO_LOADER_EP,
+            ),
+        )
+        return src_cfg_path.resolve()
 
 
 def default_loader_config(

--- a/src/datapipeline/services/scaffold/stream_plan.py
+++ b/src/datapipeline/services/scaffold/stream_plan.py
@@ -1,20 +1,29 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 
 from datapipeline.config.streams import SourceStreamConfig
+from datapipeline.io.sinks.files import AtomicBinaryFileSink
 from datapipeline.services.project import load_project
 from datapipeline.services.scaffold.domain import (
     create_domain,
+    domain_scaffold_paths,
     validate_domain_creation,
 )
-from datapipeline.services.scaffold.dto import create_dto, validate_dto_creation
+from datapipeline.services.scaffold.dto import (
+    create_dto,
+    dto_scaffold_paths,
+    validate_dto_creation,
+)
 from datapipeline.services.scaffold.layout import ep_key_from_name
+from datapipeline.services.scaffold.locking import acquire_scaffold_lock
 from datapipeline.services.scaffold.mapper import (
     create_mapper,
+    mapper_scaffold_paths,
     validate_mapper_creation,
 )
 from datapipeline.services.scaffold.parser import (
     create_parser,
+    parser_scaffold_paths,
     validate_parser_creation,
 )
 from datapipeline.services.scaffold.paths import pkg_root
@@ -23,7 +32,14 @@ from datapipeline.services.scaffold.source_yaml import (
     validate_source_id,
 )
 from datapipeline.services.scaffold.stream_yaml import write_source_stream
-from datapipeline.services.scaffold.utils import is_python_identifier
+from datapipeline.services.scaffold.utils import (
+    is_python_identifier,
+    rollback_new_scaffold_paths,
+)
+from datapipeline.services.streams.loader import (
+    declared_source_ids,
+    declared_stream_ids,
+)
 
 
 @dataclass(frozen=True)
@@ -106,100 +122,199 @@ class StreamPlanResult:
     entry_points_changed: bool
 
 
-def _preflight_stream_plan(plan: StreamPlan) -> Path:
+def _validated_stream_config(plan: StreamPlan) -> SourceStreamConfig:
     if isinstance(plan.source, SourceCreation):
         validate_source_id(plan.source.source_id)
         if isinstance(plan.source.parser, ParserCreation):
             if not is_python_identifier(plan.source.parser.dto.class_name):
                 raise ValueError("DTO name must be a valid Python identifier")
-            validate_parser_creation(plan.source.parser.name, plan.root)
 
-    if isinstance(plan.domain, DomainCreation):
-        validate_domain_creation(plan.domain.name, plan.root)
-    elif not is_python_identifier(plan.domain.name):
+    if not is_python_identifier(plan.domain.name):
         raise ValueError("Domain name must be a valid Python identifier")
-    if plan.dto_to_create is not None:
-        validate_dto_creation(plan.dto_to_create, plan.root)
-    if isinstance(plan.mapper, MapperCreation):
-        validate_mapper_creation(plan.mapper.name, plan.root)
-
-    _, _, pyproject_path = pkg_root(plan.root)
 
     mapper_entrypoint = (
         ep_key_from_name(plan.mapper.name)
         if isinstance(plan.mapper, MapperCreation)
         else plan.mapper.entrypoint
     )
-    config = SourceStreamConfig.model_validate(
+    return SourceStreamConfig.model_validate(
         {
             "id": plan.stream_id,
             "from": {"source": plan.source.source_id},
             "map": {"entrypoint": mapper_entrypoint},
         }
     )
+
+
+def _validate_component_creation(plan: StreamPlan) -> None:
+    if isinstance(plan.source, SourceCreation) and isinstance(
+        plan.source.parser, ParserCreation
+    ):
+        validate_parser_creation(plan.source.parser.name, plan.root)
+    if isinstance(plan.domain, DomainCreation):
+        validate_domain_creation(plan.domain.name, plan.root)
+    if plan.dto_to_create is not None:
+        validate_dto_creation(plan.dto_to_create, plan.root)
+    if isinstance(plan.mapper, MapperCreation):
+        validate_mapper_creation(plan.mapper.name, plan.root)
+
+
+def _validate_config_creation(
+    plan: StreamPlan,
+    config: SourceStreamConfig,
+) -> None:
+    if not plan.project_yaml.exists():
+        return
+
+    project = load_project(plan.project_yaml)
+    if isinstance(plan.source, SourceCreation):
+        source_path = project.source_dirs[0] / f"{plan.source.source_id}.yaml"
+        if source_path.exists():
+            raise FileExistsError(f"{source_path} already exists")
+    destination = project.stream_dirs[0] / f"{config.id}.yaml"
+    if destination.exists():
+        raise FileExistsError(f"{destination} already exists")
+    existing_project = replace(
+        project,
+        source_dirs=tuple(path for path in project.source_dirs if path.exists()),
+        stream_dirs=tuple(path for path in project.stream_dirs if path.exists()),
+    )
+    if isinstance(
+        plan.source, SourceCreation
+    ) and plan.source.source_id in declared_source_ids(existing_project):
+        raise FileExistsError(f"Source id '{plan.source.source_id}' already exists")
+    if config.id in declared_stream_ids(existing_project):
+        raise FileExistsError(f"Stream id '{config.id}' already exists")
+
+
+def _stream_plan_paths(
+    plan: StreamPlan,
+    config: SourceStreamConfig,
+) -> tuple[Path, ...]:
+    paths: list[Path] = []
+
+    if isinstance(plan.domain, DomainCreation):
+        paths.extend(domain_scaffold_paths(plan.domain.name, plan.root))
+    if plan.dto_to_create is not None:
+        paths.extend(dto_scaffold_paths(plan.dto_to_create, plan.root))
+    if isinstance(plan.source, SourceCreation) and isinstance(
+        plan.source.parser, ParserCreation
+    ):
+        paths.extend(parser_scaffold_paths(plan.source.parser.name, plan.root))
+    if isinstance(plan.mapper, MapperCreation):
+        paths.extend(mapper_scaffold_paths(plan.mapper.name, plan.root))
+
     if plan.project_yaml.exists():
         project = load_project(plan.project_yaml)
-        if isinstance(plan.source, SourceCreation):
-            source_path = project.source_dirs[0] / f"{plan.source.source_id}.yaml"
-            if source_path.exists():
-                raise FileExistsError(f"{source_path} already exists")
-        destination = project.stream_dirs[0] / f"{config.id}.yaml"
-        if destination.exists():
-            raise FileExistsError(f"{destination} already exists")
-    return pyproject_path
+        source_dirs = project.source_dirs
+        stream_dirs = project.stream_dirs
+        config_dirs = [*source_dirs, *stream_dirs, project.profiles_dir]
+        if project.operations_dir is not None:
+            config_dirs.append(project.operations_dir)
+    else:
+        project_dir = plan.project_yaml.parent
+        source_dirs = (project_dir / "sources",)
+        stream_dirs = (project_dir / "streams",)
+        config_dirs = [*source_dirs, *stream_dirs, project_dir / "profiles"]
+
+    paths.extend(config_dirs)
+    paths.extend((plan.project_yaml, plan.project_yaml.parent / ".env.example"))
+    if isinstance(plan.source, SourceCreation):
+        paths.append(source_dirs[0] / f"{plan.source.source_id}.yaml")
+    paths.append(stream_dirs[0] / f"{config.id}.yaml")
+    return tuple(paths)
+
+
+def _restore_pyproject(path: Path, content: bytes) -> None:
+    sink = AtomicBinaryFileSink(path.resolve())
+    try:
+        sink.write_bytes(content)
+        sink.close()
+    except BaseException:
+        sink.abort()
+        raise
 
 
 def execute_stream_plan(plan: StreamPlan) -> StreamPlanResult:
-    pyproject_path = _preflight_stream_plan(plan)
-    before_pyproject = pyproject_path.read_text(encoding="utf-8")
+    config = _validated_stream_config(plan)
+    _, _, pyproject_path = pkg_root(plan.root)
 
-    if isinstance(plan.domain, DomainCreation):
-        create_domain(plan.domain.name, plan.root)
-
-    if plan.dto_to_create is not None:
-        create_dto(plan.dto_to_create, plan.root)
-
-    if isinstance(plan.source, SourceCreation):
-        if isinstance(plan.source.parser, ParserCreation):
-            parser_entrypoint = create_parser(
-                name=plan.source.parser.name,
-                dto_class=plan.source.parser.dto.class_name,
-                dto_module=plan.source.parser.dto.module,
-                root=plan.root,
+    with acquire_scaffold_lock(pyproject_path.parent) as plugin_lock:
+        with acquire_scaffold_lock(
+            plan.project_yaml.parent,
+            plugin_lock,
+        ) as project_lock:
+            _validate_component_creation(plan)
+            _validate_config_creation(plan, config)
+            before_pyproject = pyproject_path.read_bytes()
+            entry_points_changed = isinstance(plan.mapper, MapperCreation) or (
+                isinstance(plan.source, SourceCreation)
+                and isinstance(plan.source.parser, ParserCreation)
             )
-        else:
-            parser_entrypoint = plan.source.parser.entrypoint
+            with rollback_new_scaffold_paths(_stream_plan_paths(plan, config)):
+                try:
+                    if isinstance(plan.domain, DomainCreation):
+                        create_domain(
+                            plan.domain.name,
+                            plan.root,
+                            scaffold_lock=plugin_lock,
+                        )
 
-    if isinstance(plan.mapper, MapperCreation):
-        mapper_entrypoint = create_mapper(
-            name=plan.mapper.name,
-            input_class=plan.mapper.input_type.class_name,
-            input_module=plan.mapper.input_type.module,
-            domain=plan.domain.name,
-            root=plan.root,
-        )
-    else:
-        mapper_entrypoint = plan.mapper.entrypoint
+                    if plan.dto_to_create is not None:
+                        create_dto(
+                            plan.dto_to_create,
+                            plan.root,
+                            scaffold_lock=plugin_lock,
+                        )
 
-    if isinstance(plan.source, SourceCreation):
-        create_source_yaml(
-            source_id=plan.source.source_id,
-            loader_ep=plan.source.loader_entrypoint,
-            loader_args=plan.source.loader_args,
-            parser_ep=parser_entrypoint,
-            root=plan.root,
-            project_yaml=plan.project_yaml,
-        )
+                    if isinstance(plan.source, SourceCreation):
+                        if isinstance(plan.source.parser, ParserCreation):
+                            parser_entrypoint = create_parser(
+                                name=plan.source.parser.name,
+                                dto_class=plan.source.parser.dto.class_name,
+                                dto_module=plan.source.parser.dto.module,
+                                root=plan.root,
+                                scaffold_lock=plugin_lock,
+                            )
+                        else:
+                            parser_entrypoint = plan.source.parser.entrypoint
 
-    path = write_source_stream(
-        project_yaml=plan.project_yaml,
-        stream_id=plan.stream_id,
-        source=plan.source.source_id,
-        mapper_entrypoint=mapper_entrypoint,
-    )
+                    if isinstance(plan.mapper, MapperCreation):
+                        mapper_entrypoint = create_mapper(
+                            name=plan.mapper.name,
+                            input_class=plan.mapper.input_type.class_name,
+                            input_module=plan.mapper.input_type.module,
+                            domain=plan.domain.name,
+                            root=plan.root,
+                            scaffold_lock=plugin_lock,
+                        )
+                    else:
+                        mapper_entrypoint = plan.mapper.entrypoint
 
-    after_pyproject = pyproject_path.read_text(encoding="utf-8")
-    return StreamPlanResult(
-        path=path,
-        entry_points_changed=after_pyproject != before_pyproject,
-    )
+                    if isinstance(plan.source, SourceCreation):
+                        create_source_yaml(
+                            source_id=plan.source.source_id,
+                            loader_ep=plan.source.loader_entrypoint,
+                            loader_args=plan.source.loader_args,
+                            parser_ep=parser_entrypoint,
+                            root=plan.root,
+                            project_yaml=plan.project_yaml,
+                            scaffold_lock=project_lock,
+                        )
+
+                    path = write_source_stream(
+                        project_yaml=plan.project_yaml,
+                        stream_id=plan.stream_id,
+                        source=plan.source.source_id,
+                        mapper_entrypoint=mapper_entrypoint,
+                        scaffold_lock=project_lock,
+                    )
+                except BaseException:
+                    if entry_points_changed:
+                        _restore_pyproject(pyproject_path, before_pyproject)
+                    raise
+
+            return StreamPlanResult(
+                path=path,
+                entry_points_changed=entry_points_changed,
+            )

--- a/src/datapipeline/services/scaffold/stream_yaml.py
+++ b/src/datapipeline/services/scaffold/stream_yaml.py
@@ -2,8 +2,27 @@ from pathlib import Path
 
 from datapipeline.config.streams import AlignedStreamConfig, SourceStreamConfig
 from datapipeline.services.project import load_project
+from datapipeline.services.scaffold.locking import ScaffoldLock, acquire_scaffold_lock
 from datapipeline.services.scaffold.paths import ensure_project_scaffold
 from datapipeline.services.scaffold.templates import render
+from datapipeline.services.scaffold.utils import write_new_file
+from datapipeline.services.streams.loader import declared_stream_ids
+
+
+def _new_stream_path(
+    project_yaml: Path,
+    stream_id: str,
+    scaffold_lock: ScaffoldLock,
+) -> Path:
+    if project_yaml.exists():
+        project = load_project(project_yaml)
+        path = project.stream_dirs[0] / f"{stream_id}.yaml"
+        if path.exists():
+            raise FileExistsError(f"{path} already exists")
+    project = ensure_project_scaffold(project_yaml, scaffold_lock)
+    if stream_id in declared_stream_ids(project):
+        raise FileExistsError(f"Stream id '{stream_id}' already exists")
+    return project.stream_dirs[0] / f"{stream_id}.yaml"
 
 
 def write_source_stream(
@@ -11,31 +30,25 @@ def write_source_stream(
     stream_id: str,
     source: str,
     mapper_entrypoint: str,
+    scaffold_lock: ScaffoldLock | None = None,
 ) -> Path:
-    config = SourceStreamConfig.model_validate(
-        {
-            "id": stream_id,
-            "from": {"source": source},
-            "map": {"entrypoint": mapper_entrypoint},
-        }
-    )
-    if project_yaml.exists():
-        project = load_project(project_yaml)
-        existing_path = project.stream_dirs[0] / f"{config.id}.yaml"
-        if existing_path.exists():
-            raise FileExistsError(f"{existing_path} already exists")
-    project = ensure_project_scaffold(project_yaml)
-    streams_dir = project.stream_dirs[0]
-    path = streams_dir / f"{config.id}.yaml"
-    content = render(
-        "streams/source.yaml.j2",
-        source=config.from_.source,
-        stream_id=config.id,
-        mapper_entrypoint=config.map.entrypoint,
-    )
-    with path.open("x", encoding="utf-8") as stream_file:
-        stream_file.write(content)
-    return path
+    with acquire_scaffold_lock(project_yaml.parent, scaffold_lock) as project_lock:
+        config = SourceStreamConfig.model_validate(
+            {
+                "id": stream_id,
+                "from": {"source": source},
+                "map": {"entrypoint": mapper_entrypoint},
+            }
+        )
+        path = _new_stream_path(project_yaml, config.id, project_lock)
+        content = render(
+            "streams/source.yaml.j2",
+            source=config.from_.source,
+            stream_id=config.id,
+            mapper_entrypoint=config.map.entrypoint,
+        )
+        write_new_file(path, content)
+        return path
 
 
 def write_aligned_stream(
@@ -43,31 +56,25 @@ def write_aligned_stream(
     stream_id: str,
     input_streams: list[str],
     combine_entrypoint: str,
+    scaffold_lock: ScaffoldLock | None = None,
 ) -> Path:
-    config = AlignedStreamConfig.model_validate(
-        {
-            "id": stream_id,
-            "from": {"align": input_streams},
-            "combine": {"entrypoint": combine_entrypoint},
-        }
-    )
-    if project_yaml.exists():
-        project = load_project(project_yaml)
-        existing_path = project.stream_dirs[0] / f"{config.id}.yaml"
-        if existing_path.exists():
-            raise FileExistsError(f"{existing_path} already exists")
-    project = ensure_project_scaffold(project_yaml)
-    streams_dir = project.stream_dirs[0]
-    path = streams_dir / f"{config.id}.yaml"
-    content = (
-        render(
-            "streams/aligned.yaml.j2",
-            stream_id=config.id,
-            input_streams=list(config.from_.align),
-            combine_entrypoint=config.combine.entrypoint,
-        ).strip()
-        + "\n"
-    )
-    with path.open("x", encoding="utf-8") as stream_file:
-        stream_file.write(content)
-    return path
+    with acquire_scaffold_lock(project_yaml.parent, scaffold_lock) as project_lock:
+        config = AlignedStreamConfig.model_validate(
+            {
+                "id": stream_id,
+                "from": {"align": input_streams},
+                "combine": {"entrypoint": combine_entrypoint},
+            }
+        )
+        path = _new_stream_path(project_yaml, config.id, project_lock)
+        content = (
+            render(
+                "streams/aligned.yaml.j2",
+                stream_id=config.id,
+                input_streams=list(config.from_.align),
+                combine_entrypoint=config.combine.entrypoint,
+            ).strip()
+            + "\n"
+        )
+        write_new_file(path, content)
+        return path

--- a/src/datapipeline/services/scaffold/utils.py
+++ b/src/datapipeline/services/scaffold/utils.py
@@ -1,4 +1,7 @@
+import errno
 import keyword
+from collections.abc import Iterable, Iterator
+from contextlib import contextmanager
 from pathlib import Path
 
 
@@ -14,5 +17,52 @@ def is_python_identifier(name: str) -> bool:
 
 
 def write_new_file(path: Path, text: str) -> None:
-    with path.open("x", encoding="utf-8") as file:
-        file.write(text)
+    file = path.open("x", encoding="utf-8")
+    try:
+        with file:
+            file.write(text)
+    except BaseException:
+        path.unlink(missing_ok=True)
+        raise
+
+
+def _absent_scaffold_paths(paths: Iterable[Path]) -> tuple[Path, ...]:
+    """Capture requested paths and missing parents that this scaffold may create."""
+
+    absent: list[Path] = []
+    seen: set[Path] = set()
+    for path in paths:
+        current = path
+        while not current.exists() and not current.is_symlink():
+            if current in seen:
+                break
+            absent.append(current)
+            seen.add(current)
+            current = current.parent
+    return tuple(absent)
+
+
+def _remove_scaffold_paths(paths: Iterable[Path]) -> None:
+    """Remove captured paths only when files are new or directories are empty."""
+
+    for path in sorted(set(paths), key=lambda item: len(item.parts), reverse=True):
+        if path.is_symlink() or path.is_file():
+            path.unlink(missing_ok=True)
+        elif path.is_dir():
+            try:
+                path.rmdir()
+            except OSError as exc:
+                if exc.errno not in {errno.EEXIST, errno.ENOTEMPTY}:
+                    raise
+
+
+@contextmanager
+def rollback_new_scaffold_paths(paths: Iterable[Path]) -> Iterator[None]:
+    """Remove files and empty directories first created inside this context."""
+
+    rollback_paths = _absent_scaffold_paths(paths)
+    try:
+        yield
+    except BaseException:
+        _remove_scaffold_paths(rollback_paths)
+        raise

--- a/src/datapipeline/services/streams/loader.py
+++ b/src/datapipeline/services/streams/loader.py
@@ -69,6 +69,41 @@ def _stream_from_document(
     return _STREAM_CONFIG_ADAPTER.validate_python(data)
 
 
+def _declared_ids(
+    project: ProjectManifest,
+    documents: tuple[YamlDocument, ...],
+) -> frozenset[str]:
+    ids: dict[str, Path] = {}
+    for document in documents:
+        raw_id = document.data.get("id")
+        if raw_id is None:
+            raise ValueError(f"Missing 'id' in config file: {document.path}")
+        resolved_id = resolve_config_refs(
+            raw_id,
+            project_yaml=project.path,
+            env=project.environment,
+        )
+        resolved_id = interpolate_config_vars(resolved_id, project.variables)
+        if not isinstance(resolved_id, str) or not resolved_id.strip():
+            raise ValueError(f"Invalid 'id' in config file: {document.path}")
+        resolved_id = resolved_id.strip()
+        previous = ids.get(resolved_id)
+        if previous is not None:
+            raise ValueError(
+                f"Duplicate ids in config files: {previous} and {document.path}"
+            )
+        ids[resolved_id] = document.path
+    return frozenset(ids)
+
+
+def declared_source_ids(project: ProjectManifest) -> frozenset[str]:
+    return _declared_ids(project, _source_documents(project))
+
+
+def declared_stream_ids(project: ProjectManifest) -> frozenset[str]:
+    return _declared_ids(project, _stream_documents(project))
+
+
 def _streams_from_documents(
     project: ProjectManifest,
     source_documents: tuple[YamlDocument, ...],

--- a/src/datapipeline/templates/plugin_skeleton/.gitignore
+++ b/src/datapipeline/templates/plugin_skeleton/.gitignore
@@ -1,0 +1,2 @@
+# Jerry scaffold coordination
+.jerry-scaffold.lock

--- a/src/datapipeline/templates/plugin_skeleton/pyproject.toml
+++ b/src/datapipeline/templates/plugin_skeleton/pyproject.toml
@@ -7,7 +7,7 @@ name = "{{DIST_NAME}}"
 version = "0.0.1"
 description = "A DataPipeline plugin for the {{DIST_NAME}} domain"
 dependencies = [
-  "jerry-thomas>=5.0.6",
+  "jerry-thomas>=5.0.7",
 ]
 
 [project.entry-points."datapipeline.combiners"]

--- a/src/datapipeline/templates/stubs/source.yaml.j2
+++ b/src/datapipeline/templates/stubs/source.yaml.j2
@@ -1,14 +1,14 @@
 # Required identifier for this raw source. Source-backed streams reference it under `from.source`.
-id: "{{ id }}"  # suggested format: provider.dataset
+id: {{ id | tojson }}  # suggested format: provider.dataset
 
 # parser.entrypoint: registered parser name (not a file path)
 parser:
-  entrypoint: "{{ parser_ep }}"
+  entrypoint: {{ parser_ep | tojson }}
   args:
 {{ parser_args | to_yaml(4) }}
 
 # loader.entrypoint: registered loader name (not a file path)
 loader:
-  entrypoint: "{{ loader_ep }}"
+  entrypoint: {{ loader_ep | tojson }}
   args:
 {{ loader_args | to_yaml(4) }}

--- a/src/datapipeline/templates/stubs/streams/aligned.yaml.j2
+++ b/src/datapipeline/templates/stubs/streams/aligned.yaml.j2
@@ -1,11 +1,11 @@
-id: {{ stream_id }}  # format: domain.dataset.(variant)
+id: {{ stream_id | tojson }}  # format: domain.dataset.(variant)
 
 from:
   align:
 {{ input_streams | to_yaml(indent=4) }}
 
 combine:
-  entrypoint: {{ combine_entrypoint }}
+  entrypoint: {{ combine_entrypoint | tojson }}
   args: {}
 
 # Dataset sample.keys select row identity; remaining partition fields suffix feature IDs.

--- a/src/datapipeline/templates/stubs/streams/source.yaml.j2
+++ b/src/datapipeline/templates/stubs/streams/source.yaml.j2
@@ -1,10 +1,10 @@
-id: {{ stream_id }}  # format: domain.dataset.(variant)
+id: {{ stream_id | tojson }}  # format: domain.dataset.(variant)
 
 from:
-  source: {{ source }}
+  source: {{ source | tojson }}
 
 map:
-  entrypoint: {{ mapper_entrypoint }}
+  entrypoint: {{ mapper_entrypoint | tojson }}
   args: {}
 
 # partition_by: [field]  # complete series identity; time is reserved

--- a/tests/unit/artifact_build/test_ticks_task.py
+++ b/tests/unit/artifact_build/test_ticks_task.py
@@ -88,6 +88,16 @@ def _stream_runtime(tmp_path, rows=None) -> Runtime:
     return runtime
 
 
+def test_ticks_task_rejects_time_as_grid_field() -> None:
+    with pytest.raises(ValueError, match="reserved field 'time'"):
+        TicksTask(
+            id="model_grid",
+            stream="source.stream",
+            grid_by=["time"],
+            output="build/model_grid.jsonl",
+        )
+
+
 def test_materialize_ticks_writes_sorted_unique_tick_rows(tmp_path) -> None:
     runtime = _runtime(tmp_path)
 

--- a/tests/unit/cli/test_profile_request.py
+++ b/tests/unit/cli/test_profile_request.py
@@ -1,3 +1,4 @@
+import logging
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -62,6 +63,68 @@ def test_inspect_request_requires_declared_inspect_profiles(tmp_path: Path):
             project=str(project_yaml),
         )
     assert exc.value.code == 2
+
+
+def test_pipeline_validation_does_not_log_secret_inputs(
+    tmp_path: Path,
+    monkeypatch,
+    caplog,
+) -> None:
+    project_yaml = _write_project(tmp_path)
+    secret = "do-not-log-this-secret"
+    monkeypatch.setenv("JERRY_TEST_SECRET", secret)
+    project_yaml.write_text(
+        project_yaml.read_text(encoding="utf-8").replace(
+            "artifact_revision: 1",
+            "artifact_revision: ${env:JERRY_TEST_SECRET}",
+        ),
+        encoding="utf-8",
+    )
+
+    with caplog.at_level(logging.ERROR), pytest.raises(SystemExit):
+        build_runtime_run_request(
+            command="serve",
+            project=str(project_yaml),
+        )
+
+    assert secret not in caplog.text
+    assert "input_value" not in caplog.text
+    assert "input_type" not in caplog.text
+    assert "artifact_revision" in caplog.text
+    assert "Input should be a valid integer" in caplog.text
+
+
+def test_profile_validation_does_not_log_secret_inputs(
+    tmp_path: Path,
+    monkeypatch,
+    caplog,
+) -> None:
+    project_yaml = _write_project(tmp_path)
+    secret = "do-not-log-this-secret"
+    monkeypatch.setenv("JERRY_TEST_SECRET", secret)
+    profiles = tmp_path / "profiles"
+    profiles.mkdir()
+    (profiles / "serve.dataset.yaml").write_text(
+        """\
+operation: dataset
+observability:
+  logging:
+    level: ${env:JERRY_TEST_SECRET}
+""",
+        encoding="utf-8",
+    )
+
+    with caplog.at_level(logging.ERROR), pytest.raises(SystemExit):
+        build_runtime_run_request(
+            command="serve",
+            project=str(project_yaml),
+        )
+
+    assert secret not in caplog.text
+    assert "input_value" not in caplog.text
+    assert "input_type" not in caplog.text
+    assert "logging.level" in caplog.text
+    assert "level must be one of" in caplog.text
 
 
 def test_inspect_request_materializes_execution_scoped_log_output(

--- a/tests/unit/cli/test_profile_request.py
+++ b/tests/unit/cli/test_profile_request.py
@@ -124,7 +124,36 @@ observability:
     assert "input_value" not in caplog.text
     assert "input_type" not in caplog.text
     assert "logging.level" in caplog.text
-    assert "level must be one of" in caplog.text
+    assert "Invalid configuration value" in caplog.text
+
+
+def test_custom_validation_message_does_not_log_resolved_secret(
+    tmp_path: Path,
+    monkeypatch,
+    caplog,
+) -> None:
+    project_yaml = _write_project(tmp_path)
+    secret = "do-not-log-this-output-id"
+    monkeypatch.setenv("JERRY_TEST_SECRET", secret)
+    profiles = tmp_path / "profiles"
+    profiles.mkdir()
+    (profiles / "serve.dataset.yaml").write_text(
+        "operation: dataset\n"
+        "include_outputs:\n"
+        "  - ${env:JERRY_TEST_SECRET}\n"
+        "  - ${env:JERRY_TEST_SECRET}\n",
+        encoding="utf-8",
+    )
+
+    with caplog.at_level(logging.ERROR), pytest.raises(SystemExit):
+        build_runtime_run_request(
+            command="serve",
+            project=str(project_yaml),
+        )
+
+    assert secret not in caplog.text
+    assert "include_outputs" in caplog.text
+    assert "Invalid configuration value" in caplog.text
 
 
 def test_inspect_request_materializes_execution_scoped_log_output(

--- a/tests/unit/cli/test_scaffold_plugin.py
+++ b/tests/unit/cli/test_scaffold_plugin.py
@@ -155,6 +155,9 @@ def test_scaffold_plugin_normalizes_hyphenated_name(tmp_path: Path) -> None:
     assert (dataset_root / "profiles" / "serve.dataset.yaml").is_file()
     assert (dataset_root / "profiles" / "serve.defaults.yaml").is_file()
     assert (plugin_root / "src" / "test_datapipeline" / "combiners").is_dir()
+    assert ".jerry-scaffold.lock" in (plugin_root / ".gitignore").read_text(
+        encoding="utf-8"
+    )
 
     pyproject = (plugin_root / "pyproject.toml").read_text()
     assert 'name = "test-datapipeline"' in pyproject

--- a/tests/unit/cli/test_scaffold_python_commands.py
+++ b/tests/unit/cli/test_scaffold_python_commands.py
@@ -11,6 +11,10 @@ class PromptAborted(Exception):
     pass
 
 
+def _raise_write_failure(*args, **kwargs):
+    raise OSError("write failed")
+
+
 def _create_plugin(tmp_path: Path) -> Path:
     root = tmp_path / "plugin"
     package = root / "src" / "sample_plugin"
@@ -216,4 +220,65 @@ def test_mapper_collision_does_not_create_selected_dependencies(
     assert not (package / "domains").exists()
     if collision == "file":
         assert mapper_path.read_text(encoding="utf-8") == "existing mapper\n"
+    assert pyproject.read_bytes() == original_pyproject
+
+
+def test_parser_rolls_back_created_dto_when_registration_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    plugin = _create_plugin(tmp_path)
+    package = plugin / "src" / "sample_plugin"
+    pyproject = plugin / "pyproject.toml"
+    original_pyproject = pyproject.read_bytes()
+    monkeypatch.setattr(
+        "datapipeline.cli.commands.parser.choose_dto",
+        lambda existing, default=None: ("WeatherDTO", True),
+    )
+    monkeypatch.setattr(
+        "datapipeline.services.scaffold.entrypoints._write_document",
+        _raise_write_failure,
+    )
+
+    with pytest.raises(OSError, match="write failed"):
+        handle_parser("WeatherParser", plugin_root=plugin)
+
+    assert (package / "__init__.py").exists()
+    assert not (package / "dtos").exists()
+    assert not (package / "parsers").exists()
+    assert pyproject.read_bytes() == original_pyproject
+
+
+def test_mapper_rolls_back_created_dependencies_when_registration_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    plugin = _create_plugin(tmp_path)
+    package = plugin / "src" / "sample_plugin"
+    pyproject = plugin / "pyproject.toml"
+    original_pyproject = pyproject.read_bytes()
+    monkeypatch.setattr(
+        "datapipeline.cli.commands.mapper.pick_from_menu",
+        lambda *args, **kwargs: "dto",
+    )
+    monkeypatch.setattr(
+        "datapipeline.cli.commands.mapper.choose_dto",
+        lambda existing, default=None: ("WeatherDTO", True),
+    )
+    monkeypatch.setattr(
+        "datapipeline.cli.commands.mapper.choose_domain",
+        lambda existing, default=None: ("weather", True),
+    )
+    monkeypatch.setattr(
+        "datapipeline.services.scaffold.entrypoints._write_document",
+        _raise_write_failure,
+    )
+
+    with pytest.raises(OSError, match="write failed"):
+        handle_mapper("map_weather", plugin_root=plugin)
+
+    assert (package / "__init__.py").exists()
+    assert not (package / "dtos").exists()
+    assert not (package / "domains").exists()
+    assert not (package / "mappers").exists()
     assert pyproject.read_bytes() == original_pyproject

--- a/tests/unit/cli/test_scaffold_source.py
+++ b/tests/unit/cli/test_scaffold_source.py
@@ -3,6 +3,8 @@ from pathlib import Path
 import pytest
 import yaml
 
+from datapipeline.config.sources import SourceConfig
+from datapipeline.services.scaffold.paths import ensure_project_scaffold
 from datapipeline.services.scaffold.source_yaml import (
     create_source_yaml,
     default_loader_config,
@@ -55,6 +57,43 @@ def test_create_source_preserves_custom_source_id(tmp_path: Path) -> None:
     )
 
 
+def test_create_source_quotes_yaml_sensitive_entrypoints(tmp_path: Path) -> None:
+    plugin_root = _create_plugin(tmp_path)
+    path = create_source_yaml(
+        source_id="demo.weather",
+        loader_ep='custom"loader\\name',
+        loader_args={},
+        parser_ep='custom"parser\\name',
+        root=plugin_root,
+    )
+
+    source = SourceConfig.model_validate(
+        yaml.safe_load(path.read_text(encoding="utf-8"))
+    )
+
+    assert source.loader.entrypoint == 'custom"loader\\name'
+    assert source.parser.entrypoint == 'custom"parser\\name'
+
+
+def test_create_pickle_source_satisfies_source_contract(tmp_path: Path) -> None:
+    plugin_root = _create_plugin(tmp_path)
+    loader_ep, loader_args = default_loader_config("fs", "pickle")
+    path = create_source_yaml(
+        source_id="demo.weather",
+        loader_ep=loader_ep,
+        loader_args=loader_args,
+        parser_ep="identity",
+        root=plugin_root,
+    )
+
+    source = SourceConfig.model_validate(
+        yaml.safe_load(path.read_text(encoding="utf-8"))
+    )
+
+    assert source.loader.args.format == "pickle"
+    assert "encoding" not in source.loader.args.model_fields_set
+
+
 def test_default_loader_config_rejects_unknown_transport() -> None:
     with pytest.raises(ValueError, match="Unsupported source transport"):
         default_loader_config("unknown", None)
@@ -81,6 +120,73 @@ def test_create_source_refuses_to_replace_existing_config(tmp_path: Path) -> Non
         )
 
     assert path.read_bytes() == original
+
+
+def test_create_source_rejects_existing_id_in_another_root(tmp_path: Path) -> None:
+    plugin_root = _create_plugin(tmp_path)
+    project_yaml = plugin_root / "your-dataset" / "project.yaml"
+    project = ensure_project_scaffold(project_yaml)
+    common_sources = plugin_root / "common" / "sources"
+    common_sources.mkdir(parents=True)
+    project_yaml.write_text(
+        project_yaml.read_text(encoding="utf-8").replace(
+            "  sources: ./sources",
+            "  sources: [./sources, ../common/sources]",
+        ),
+        encoding="utf-8",
+    )
+    (common_sources / "existing.yaml").write_text(
+        "id: demo.weather\n"
+        "parser: {entrypoint: identity}\n"
+        "loader: {entrypoint: identity}\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(FileExistsError, match="Source id 'demo.weather'"):
+        create_source_yaml(
+            source_id="demo.weather",
+            loader_ep="custom.loader",
+            loader_args={},
+            parser_ep="identity",
+            root=plugin_root,
+            project_yaml=project_yaml,
+        )
+
+    assert not (project.source_dirs[0] / "demo.weather.yaml").exists()
+
+
+def test_create_source_does_not_validate_unrelated_source_values(
+    tmp_path: Path,
+) -> None:
+    plugin_root = _create_plugin(tmp_path)
+    project_yaml = plugin_root / "your-dataset" / "project.yaml"
+    project = ensure_project_scaffold(project_yaml)
+    (project_yaml.parent / ".env").write_text(
+        "SECRET=TOP-SECRET-VALUE\n",
+        encoding="utf-8",
+    )
+    (project.source_dirs[0] / "existing.yaml").write_text(
+        "id: demo.existing\n"
+        "parser: {entrypoint: identity}\n"
+        "loader:\n"
+        "  entrypoint: core.io\n"
+        "  args:\n"
+        "    transport: ${env:SECRET}\n"
+        "    format: jsonl\n"
+        "    path: data.jsonl\n",
+        encoding="utf-8",
+    )
+
+    path = create_source_yaml(
+        source_id="demo.weather",
+        loader_ep="custom.loader",
+        loader_args={},
+        parser_ep="identity",
+        root=plugin_root,
+        project_yaml=project_yaml,
+    )
+
+    assert path.name == "demo.weather.yaml"
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/cli/test_source_command.py
+++ b/tests/unit/cli/test_source_command.py
@@ -105,6 +105,21 @@ def test_source_create_rejects_unsafe_source_id_before_loader_selection() -> Non
     assert exc.value.code == 2
 
 
+def test_source_create_rejects_pickle_over_http(caplog) -> None:
+    with pytest.raises(SystemExit) as exc:
+        source.handle(
+            subcmd="create",
+            provider="demo",
+            dataset="weather",
+            transport="http",
+            format="pickle",
+            parser="identity",
+        )
+
+    assert exc.value.code == 2
+    assert "not supported for http" in caplog.text
+
+
 def test_interactive_parser_menu_can_select_temporal_record(monkeypatch) -> None:
     monkeypatch.setattr(source.sys, "stdin", SimpleNamespace(isatty=lambda: True))
     monkeypatch.setattr(source, "list_parsers", lambda root=None: {})

--- a/tests/unit/cli/test_stream_create_cli.py
+++ b/tests/unit/cli/test_stream_create_cli.py
@@ -138,8 +138,8 @@ def test_stream_identity_mapper_skips_scaffold(
 
     stream_path = streams_dir / "weather.weather.yaml"
     assert stream_path.exists()
-    text = stream_path.read_text()
-    assert "entrypoint: identity" in text
+    document = yaml.safe_load(stream_path.read_text(encoding="utf-8"))
+    assert document["map"]["entrypoint"] == "identity"
     package = plugin_root / "src" / "sample_plugin"
     assert not (package / "dtos").exists()
     assert not (package / "domains").exists()

--- a/tests/unit/cli/test_streams_rich.py
+++ b/tests/unit/cli/test_streams_rich.py
@@ -25,8 +25,7 @@ from datapipeline.cli.visuals.execution_context import (
 )
 from datapipeline.cli.visuals.rich.progress import (
     _ExecutionProgress,
-    _ProgressActivityColumn,
-    _ProgressLabelColumn,
+    _ProgressRowColumn,
     _RichExecutionRenderer,
     rich_visuals_supported,
     visual_execution,
@@ -66,6 +65,12 @@ def _console(width: int | None = None) -> tuple[Console, StringIO]:
 def _progress() -> Progress:
     console, _ = _console()
     return Progress(console=console, auto_refresh=False)
+
+
+def _render_progress_row(task) -> str:
+    console, output = _console(width=200)
+    console.print(_ProgressRowColumn(Column()).render(task))
+    return output.getvalue().rstrip()
 
 
 class _CaptureRenderer:
@@ -168,8 +173,8 @@ def test_info_progress_shows_node_and_local_detail() -> None:
     assert open_source.visible is True
     assert open_source.completed == 20_000
     assert open_source.fields["status"] == ('2/17 "2011.jsonl" · 20,000 records')
-    assert _ProgressActivityColumn(Column()).render(open_source).plain == (
-        '2/17 "2011.jsonl" · 20,000 records'
+    assert _render_progress_row(open_source) == (
+        '[stream:adv.20/open_source] 0:00:00 2/17 "2011.jsonl" · 20,000 records'
     )
 
     with patch.object(progress, "refresh", wraps=progress.refresh) as refresh:
@@ -259,13 +264,18 @@ def test_info_elapsed_continues_after_completed_local_phase() -> None:
         )
     )
     root, order_records = progress.tasks
-    label = _ProgressLabelColumn(Column()).render(root)
-    assert label.plain == "[stream:adv.20] 0:00:10"
-    assert label.spans == []
-    assert _ProgressLabelColumn(Column()).render(order_records).plain == (
+    row = _ProgressRowColumn(Column()).render(root)
+    assert _render_progress_row(root) == "[stream:adv.20] 0:00:10"
+    console, _ = _console(width=200)
+    timer = next(
+        segment
+        for segment in console.render(row, console.options)
+        if "0:00:10" in segment.text
+    )
+    assert str(timer.style) == "cyan"
+    assert _render_progress_row(order_records).startswith(
         "[stream:adv.20/order_records] 0:00:10"
     )
-    assert _ProgressActivityColumn(Column()).render(root).plain == ""
     assert root.description == "[stream:adv.20]"
     assert root.total is None
     assert root.completed == 0
@@ -282,10 +292,8 @@ def test_info_elapsed_continues_after_completed_local_phase() -> None:
     )
 
     root, order_records = progress.tasks
-    assert _ProgressLabelColumn(Column()).render(root).plain == (
-        "[stream:adv.20] 0:00:20"
-    )
-    assert _ProgressLabelColumn(Column()).render(order_records).plain == (
+    assert _render_progress_row(root) == "[stream:adv.20] 0:00:20"
+    assert _render_progress_row(order_records).startswith(
         "[stream:adv.20/order_records] 0:00:20"
     )
     assert root.description == "[stream:adv.20]"
@@ -328,14 +336,14 @@ def test_debug_progress_shows_root_and_active_nodes() -> None:
         ("[stream:adv.20/decode_records]", "0 out"),
     ]
     root_task, order_task, source_task, _ = tasks
-    label = _ProgressLabelColumn(Column())
-    activity_column = _ProgressActivityColumn(Column())
-    assert label.render(root_task).plain == "[stream:adv.20] 0:00:00"
-    assert activity_column.render(root_task).plain == ""
-    assert activity_column.render(order_task).plain == "0 out"
+    row_column = _ProgressRowColumn(Column())
+    assert _render_progress_row(root_task) == "[stream:adv.20] 0:00:00"
+    assert _render_progress_row(order_task) == (
+        "[stream:adv.20/order_records] 0:00:00 0 out"
+    )
     assert source_task.completed == 25
     assert source_task.total == 100
-    bar = activity_column._bar.render(source_task)
+    bar = row_column._bar.render(source_task)
     assert bar.completed == 25
     assert bar.total == 100
 
@@ -390,16 +398,15 @@ def test_operation_progress_stays_live_across_sequential_pipelines() -> None:
     )
 
     operation = progress.tasks[0]
-    assert operation.description == "Elapsed"
-    assert operation.fields["status"] == "write_output · 2,592,885 rows"
-    assert _ProgressLabelColumn(Column()).render(operation).plain == ("Elapsed 0:00:10")
-    assert _ProgressActivityColumn(Column()).render(operation).plain == (
-        "write_output · 2,592,885 rows"
+    assert operation.description == "Operation serve:dataset"
+    assert operation.fields["status"] == ("last report: write_output · 2,592,885 rows")
+    assert _render_progress_row(operation) == (
+        "Operation serve:dataset 0:00:10 last report: write_output · 2,592,885 rows"
     )
 
     renderer.handle(PipelineStarted(pipeline_name="dataset:fold_0", node_count=5))
     assert [task.description for task in progress.tasks] == [
-        "Elapsed",
+        "Operation serve:dataset",
         "[dataset:fold_0]",
     ]
     renderer.handle(
@@ -411,15 +418,44 @@ def test_operation_progress_stays_live_across_sequential_pipelines() -> None:
             elapsed_seconds=1,
         )
     )
-    assert [task.description for task in progress.tasks] == ["Elapsed"]
+    assert [task.description for task in progress.tasks] == ["Operation serve:dataset"]
 
     renderer.handle(PipelineStarted(pipeline_name="dataset:fold_1", node_count=5))
     assert [task.description for task in progress.tasks] == [
-        "Elapsed",
+        "Operation serve:dataset",
         "[dataset:fold_1]",
     ]
     renderer.handle(OperationFinished("serve:dataset", "success", 20))
     assert progress.tasks == []
+
+
+def test_determinate_progress_stays_on_one_line_at_standard_width() -> None:
+    console, output = _console(width=80)
+    progress = Progress(
+        _ProgressRowColumn(Column(no_wrap=True, overflow="ellipsis")),
+        console=console,
+        auto_refresh=False,
+    )
+    progress.add_task(
+        "Operation serve:dataset",
+        total=None,
+        status="last report: write_output · 1,974,178 rows",
+    )
+    progress.add_task(
+        "[dataset:fold_1/vector_assemble]",
+        completed=7_605_305,
+        total=8_600_417,
+        status="emitting · 7,605,305/8,600,417 items",
+    )
+
+    console.print(progress.get_renderable())
+
+    lines = output.getvalue().splitlines()
+    assert len(lines) == 2
+    assert "Operation serve:dataset 0:00:00 last report:" in lines[0]
+    assert "0:00:00" in lines[1]
+    assert "━" in lines[1]
+    assert "emitting" in lines[1]
 
 
 def test_rich_renderer_routes_node_progress_without_printing() -> None:
@@ -719,7 +755,7 @@ def test_rich_renderer_renders_file_result_as_aligned_link() -> None:
     ]
     assert "".join(segment.text for segment in linked) == str(path)
     assert all(
-        segment.style.color is not None and segment.style.color.name == "blue"
+        segment.style.color is not None and segment.style.color.name == "bright_blue"
         for segment in linked
     )
 
@@ -848,8 +884,8 @@ def test_visual_execution_uses_minimal_progress_styles(monkeypatch) -> None:
     with visual_execution(logging.INFO):
         pass
 
-    label, activity = columns[:2]
-    assert isinstance(label, _ProgressLabelColumn)
-    assert isinstance(activity, _ProgressActivityColumn)
-    assert activity._bar.complete_style == "cyan"
-    assert activity._bar.finished_style == "cyan"
+    assert len(columns) == 1
+    row = columns[0]
+    assert isinstance(row, _ProgressRowColumn)
+    assert row._bar.complete_style == "cyan"
+    assert row._bar.finished_style == "cyan"

--- a/tests/unit/execution/test_pipeline_stream.py
+++ b/tests/unit/execution/test_pipeline_stream.py
@@ -79,11 +79,16 @@ class _CollectingObserver:
 
 
 class _ProcessingAndCleanupFailure(Iterator[int]):
-    def __init__(self) -> None:
+    def __init__(self, processing_error: BaseException | None = None) -> None:
+        self.processing_error = (
+            processing_error
+            if processing_error is not None
+            else RuntimeError("processing failed")
+        )
         self.closed = False
 
     def __next__(self) -> int:
-        raise RuntimeError("processing failed")
+        raise self.processing_error
 
     def close(self) -> None:
         self.closed = True
@@ -721,6 +726,7 @@ def test_none_node_output_is_rejected(
     [
         (RuntimeError("boom"), "boom"),
         (KeyboardInterrupt(), None),
+        (SystemExit(2), "2"),
     ],
 )
 def test_stage_failures_reach_node_and_pipeline_events(
@@ -759,38 +765,50 @@ def test_stage_failures_reach_node_and_pipeline_events(
     assert pipeline_event.error_message == message
 
 
-def test_node_cleanup_does_not_replace_processing_failure(tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    "processing_error",
+    [RuntimeError("processing failed"), SystemExit(2)],
+)
+def test_node_cleanup_does_not_replace_processing_failure(
+    tmp_path: Path,
+    processing_error: BaseException,
+) -> None:
     observer = _CollectingObserver()
-    stream = _ProcessingAndCleanupFailure()
+    stream = _ProcessingAndCleanupFailure(processing_error)
     pipeline = Pipeline(
         name="failure",
         nodes=(SourceNode("source", lambda: stream),),
     )
 
-    with pytest.raises(RuntimeError, match="processing failed"):
+    with pytest.raises(type(processing_error), match=str(processing_error)):
         list(run_pipeline(_context(tmp_path), pipeline, observer=observer))
 
     node_event = _events_by_name(observer)["source"]
     assert node_event.status == "error"
-    assert node_event.error_type == "RuntimeError"
-    assert node_event.error_message == "processing failed"
+    assert node_event.error_type == type(processing_error).__name__
+    assert node_event.error_message == str(processing_error)
     pipeline_event = observer.pipeline_events[-1]
     assert pipeline_event.status == "error"
-    assert pipeline_event.error_type == "RuntimeError"
-    assert pipeline_event.error_message == "processing failed"
+    assert pipeline_event.error_type == type(processing_error).__name__
+    assert pipeline_event.error_message == str(processing_error)
     assert stream.closed
 
 
+@pytest.mark.parametrize(
+    "processing_error",
+    [RuntimeError("processing failed"), SystemExit(2)],
+)
 def test_unobserved_cleanup_does_not_replace_processing_failure(
     tmp_path: Path,
+    processing_error: BaseException,
 ) -> None:
-    stream = _ProcessingAndCleanupFailure()
+    stream = _ProcessingAndCleanupFailure(processing_error)
     pipeline = Pipeline(
         name="failure",
         nodes=(SourceNode("source", lambda: stream),),
     )
 
-    with pytest.raises(RuntimeError, match="processing failed"):
+    with pytest.raises(type(processing_error), match=str(processing_error)):
         list(run_pipeline(_context(tmp_path), pipeline))
 
     assert stream.closed

--- a/tests/unit/execution/test_pipeline_stream.py
+++ b/tests/unit/execution/test_pipeline_stream.py
@@ -78,6 +78,18 @@ class _CollectingObserver:
             )
 
 
+class _ProcessingAndCleanupFailure(Iterator[int]):
+    def __init__(self) -> None:
+        self.closed = False
+
+    def __next__(self) -> int:
+        raise RuntimeError("processing failed")
+
+    def close(self) -> None:
+        self.closed = True
+        raise OSError("cleanup failed")
+
+
 def _context(tmp_path: Path) -> PipelineContext:
     project_yaml = tmp_path / "project.yaml"
     project_yaml.write_text(
@@ -745,6 +757,43 @@ def test_stage_failures_reach_node_and_pipeline_events(
     assert pipeline_event.status == "error"
     assert pipeline_event.error_type == type(error).__name__
     assert pipeline_event.error_message == message
+
+
+def test_node_cleanup_does_not_replace_processing_failure(tmp_path: Path) -> None:
+    observer = _CollectingObserver()
+    stream = _ProcessingAndCleanupFailure()
+    pipeline = Pipeline(
+        name="failure",
+        nodes=(SourceNode("source", lambda: stream),),
+    )
+
+    with pytest.raises(RuntimeError, match="processing failed"):
+        list(run_pipeline(_context(tmp_path), pipeline, observer=observer))
+
+    node_event = _events_by_name(observer)["source"]
+    assert node_event.status == "error"
+    assert node_event.error_type == "RuntimeError"
+    assert node_event.error_message == "processing failed"
+    pipeline_event = observer.pipeline_events[-1]
+    assert pipeline_event.status == "error"
+    assert pipeline_event.error_type == "RuntimeError"
+    assert pipeline_event.error_message == "processing failed"
+    assert stream.closed
+
+
+def test_unobserved_cleanup_does_not_replace_processing_failure(
+    tmp_path: Path,
+) -> None:
+    stream = _ProcessingAndCleanupFailure()
+    pipeline = Pipeline(
+        name="failure",
+        nodes=(SourceNode("source", lambda: stream),),
+    )
+
+    with pytest.raises(RuntimeError, match="processing failed"):
+        list(run_pipeline(_context(tmp_path), pipeline))
+
+    assert stream.closed
 
 
 def test_node_cleanup_failure_emits_failed_finish_event(tmp_path: Path) -> None:

--- a/tests/unit/integrations/test_ml_rows.py
+++ b/tests/unit/integrations/test_ml_rows.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -5,6 +6,7 @@ import pytest
 
 import datapipeline.integrations.ml.adapter as adapter_module
 import datapipeline.integrations.ml.rows as rows_module
+from datapipeline.artifacts.specs import VECTOR_SCHEMA
 from datapipeline.config.dataset.dataset import FeatureDatasetConfig, SampleConfig
 from datapipeline.config.dataset.feature import FeatureRecordConfig
 from datapipeline.config.dataset.split import (
@@ -173,6 +175,94 @@ def test_vector_adapter_scales_unsplit_dataset_when_configured(
     assert calls == ["scaled"]
 
 
+def test_vector_adapter_row_columns_expand_sequences(tmp_path: Path) -> None:
+    runtime = _runtime_with_schema(
+        tmp_path,
+        {
+            "schema_version": 2,
+            "features": [
+                {"id": "closing_price", "kind": "scalar"},
+                {
+                    "id": "price_history",
+                    "kind": "list",
+                    "cadence": {"target": 3},
+                },
+            ],
+            "targets": [
+                {
+                    "id": "future_returns",
+                    "kind": "list",
+                    "cadence": {"target": 2},
+                }
+            ],
+        },
+    )
+    adapter = VectorAdapter(dataset=runtime.dataset, runtime=runtime)
+
+    assert adapter.row_columns(flatten_sequences=True) == (
+        [
+            "closing_price",
+            "price_history[0]",
+            "price_history[1]",
+            "price_history[2]",
+        ],
+        ["future_returns[0]", "future_returns[1]"],
+    )
+
+
+def test_vector_adapter_rejects_flattened_row_column_collisions(
+    tmp_path: Path,
+) -> None:
+    runtime = _runtime_with_schema(
+        tmp_path,
+        {
+            "schema_version": 2,
+            "features": [
+                {"id": "history[0]", "kind": "scalar"},
+                {
+                    "id": "history",
+                    "kind": "list",
+                    "cadence": {"target": 1},
+                },
+            ],
+            "targets": [],
+        },
+    )
+    adapter = VectorAdapter(dataset=runtime.dataset, runtime=runtime)
+
+    with pytest.raises(ValueError, match="Flattened row column 'history\\[0\\]'"):
+        list(adapter.iter_rows(flatten_sequences=True))
+
+
+def test_vector_adapter_ignores_columns_removed_by_postprocess(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    runtime = _runtime_with_schema(
+        tmp_path,
+        {
+            "schema_version": 2,
+            "features": [
+                {"id": "history[0]", "kind": "scalar"},
+                {
+                    "id": "history",
+                    "kind": "list",
+                    "cadence": {"target": 1},
+                },
+            ],
+            "targets": [],
+        },
+    )
+    monkeypatch.setattr(
+        adapter_module,
+        "build_postprocess_plan",
+        lambda _context: SimpleNamespace(feature_ids=("history",), target_ids=()),
+    )
+    adapter = VectorAdapter(dataset=runtime.dataset, runtime=runtime)
+
+    assert adapter.row_columns(flatten_sequences=True) == (["history[0]"], [])
+
+
 def _dataset(
     *,
     split: TimeSplitConfig | None = None,
@@ -233,3 +323,18 @@ def _runtime(
         artifacts_root=tmp_path / "artifacts",
         dataset=dataset,
     )
+
+
+def _runtime_with_schema(
+    tmp_path: Path,
+    document: dict[str, object],
+) -> Runtime:
+    runtime = _runtime(
+        tmp_path,
+        FeatureDatasetConfig(sample=SampleConfig(cadence="1h")),
+    )
+    runtime.artifacts_root.mkdir()
+    schema_path = runtime.artifacts_root / "schema.json"
+    schema_path.write_text(json.dumps(document), encoding="utf-8")
+    runtime.artifacts.register(VECTOR_SCHEMA, relative_path="schema.json")
+    return runtime

--- a/tests/unit/integrations/test_torch_support.py
+++ b/tests/unit/integrations/test_torch_support.py
@@ -1,94 +1,9 @@
-import json
 import sys
 from types import ModuleType, SimpleNamespace
 
 import datapipeline.integrations.ml.torch_support as torch_support
-from datapipeline.artifacts.specs import VECTOR_SCHEMA
 from datapipeline.config.dataset.dataset import FeatureDatasetConfig, SampleConfig
-from datapipeline.integrations.ml.torch_support import _resolve_columns, _schema_columns
-from datapipeline.runtime import Runtime
-
-
-def _runtime_with_schema(tmp_path, document: dict[str, object]) -> Runtime:
-    project_yaml = tmp_path / "project.yaml"
-    project_yaml.write_text(
-        "schema_version: 2\nartifact_revision: 1\n", encoding="utf-8"
-    )
-    artifacts_root = tmp_path / "artifacts"
-    artifacts_root.mkdir()
-    runtime = Runtime(
-        project_yaml=project_yaml,
-        artifacts_root=artifacts_root,
-        dataset=FeatureDatasetConfig(sample=SampleConfig(cadence="1h")),
-    )
-    schema_path = artifacts_root / "schema.json"
-    schema_path.write_text(json.dumps(document), encoding="utf-8")
-    runtime.artifacts.register(VECTOR_SCHEMA, relative_path="schema.json")
-    return runtime
-
-
-def test_schema_columns_preserve_ids_and_expand_sequences(tmp_path) -> None:
-    runtime = _runtime_with_schema(
-        tmp_path,
-        {
-            "schema_version": 2,
-            "features": [
-                {"id": "closing_price__@ticker:AACB", "kind": "scalar"},
-                {"id": "closing_price__@ticker:ZWS", "kind": "scalar"},
-                {
-                    "id": "price_history",
-                    "kind": "list",
-                    "cadence": {"target": 3},
-                },
-            ],
-            "targets": [
-                {
-                    "id": "fwd_excess_return_126d_vs_spy__@ticker:AACB",
-                    "kind": "scalar",
-                },
-                {
-                    "id": "fwd_excess_return_126d_vs_spy__@ticker:ZWS",
-                    "kind": "scalar",
-                },
-                {
-                    "id": "future_returns",
-                    "kind": "list",
-                    "cadence": {"target": 2},
-                },
-            ],
-        },
-    )
-
-    feature_columns, target_columns = _schema_columns(SimpleNamespace(runtime=runtime))
-
-    assert feature_columns == [
-        "closing_price__@ticker:AACB",
-        "closing_price__@ticker:ZWS",
-        "price_history",
-    ]
-    assert target_columns == [
-        "fwd_excess_return_126d_vs_spy__@ticker:AACB",
-        "fwd_excess_return_126d_vs_spy__@ticker:ZWS",
-        "future_returns",
-    ]
-    flattened_features, flattened_targets = _schema_columns(
-        SimpleNamespace(runtime=runtime),
-        flatten_sequences=True,
-    )
-
-    assert flattened_features == [
-        "closing_price__@ticker:AACB",
-        "closing_price__@ticker:ZWS",
-        "price_history[0]",
-        "price_history[1]",
-        "price_history[2]",
-    ]
-    assert flattened_targets == [
-        "fwd_excess_return_126d_vs_spy__@ticker:AACB",
-        "fwd_excess_return_126d_vs_spy__@ticker:ZWS",
-        "future_returns[0]",
-        "future_returns[1]",
-    ]
+from datapipeline.integrations.ml.torch_support import _resolve_columns
 
 
 def test_torch_dataset_reads_flattened_sequence_columns(
@@ -97,6 +12,10 @@ def test_torch_dataset_reads_flattened_sequence_columns(
 ) -> None:
     adapter = SimpleNamespace(
         dataset=FeatureDatasetConfig(sample=SampleConfig(cadence="1h")),
+        row_columns=lambda flatten_sequences=False: (
+            ["history[0]", "history[1]"],
+            [],
+        ),
         iter_rows=lambda **_kwargs: [{"history[0]": 1.0, "history[1]": 2.0}],
     )
     monkeypatch.setattr(
@@ -104,14 +23,6 @@ def test_torch_dataset_reads_flattened_sequence_columns(
         "from_project",
         lambda _path, output_id=None: adapter,
     )
-    flatten_options = []
-
-    def schema_columns(_adapter, flatten_sequences=False):
-        flatten_options.append(flatten_sequences)
-        return ["history[0]", "history[1]"], []
-
-    monkeypatch.setattr(torch_support, "_schema_columns", schema_columns)
-
     torch = ModuleType("torch")
     torch.as_tensor = lambda values, **_kwargs: tuple(values)
     torch.tensor = lambda values, **_kwargs: tuple(values)
@@ -128,7 +39,6 @@ def test_torch_dataset_reads_flattened_sequence_columns(
     )
 
     assert dataset[0] == (1.0, 2.0)
-    assert flatten_options == [True]
 
 
 def test_resolve_columns_excludes_partitioned_targets_from_features() -> None:

--- a/tests/unit/integrations/test_torch_support.py
+++ b/tests/unit/integrations/test_torch_support.py
@@ -1,13 +1,15 @@
 import json
-from types import SimpleNamespace
+import sys
+from types import ModuleType, SimpleNamespace
 
+import datapipeline.integrations.ml.torch_support as torch_support
 from datapipeline.artifacts.specs import VECTOR_SCHEMA
 from datapipeline.config.dataset.dataset import FeatureDatasetConfig, SampleConfig
 from datapipeline.integrations.ml.torch_support import _resolve_columns, _schema_columns
 from datapipeline.runtime import Runtime
 
 
-def test_schema_columns_include_partitioned_target_ids(tmp_path) -> None:
+def _runtime_with_schema(tmp_path, document: dict[str, object]) -> Runtime:
     project_yaml = tmp_path / "project.yaml"
     project_yaml.write_text(
         "schema_version: 2\nartifact_revision: 1\n", encoding="utf-8"
@@ -20,40 +22,113 @@ def test_schema_columns_include_partitioned_target_ids(tmp_path) -> None:
         dataset=FeatureDatasetConfig(sample=SampleConfig(cadence="1h")),
     )
     schema_path = artifacts_root / "schema.json"
-    schema_path.write_text(
-        json.dumps(
-            {
-                "schema_version": 2,
-                "features": [
-                    {"id": "closing_price__@ticker:AACB", "kind": "scalar"},
-                    {"id": "closing_price__@ticker:ZWS", "kind": "scalar"},
-                ],
-                "targets": [
-                    {
-                        "id": "fwd_excess_return_126d_vs_spy__@ticker:AACB",
-                        "kind": "scalar",
-                    },
-                    {
-                        "id": "fwd_excess_return_126d_vs_spy__@ticker:ZWS",
-                        "kind": "scalar",
-                    },
-                ],
-            }
-        ),
-        encoding="utf-8",
-    )
+    schema_path.write_text(json.dumps(document), encoding="utf-8")
     runtime.artifacts.register(VECTOR_SCHEMA, relative_path="schema.json")
+    return runtime
+
+
+def test_schema_columns_preserve_ids_and_expand_sequences(tmp_path) -> None:
+    runtime = _runtime_with_schema(
+        tmp_path,
+        {
+            "schema_version": 2,
+            "features": [
+                {"id": "closing_price__@ticker:AACB", "kind": "scalar"},
+                {"id": "closing_price__@ticker:ZWS", "kind": "scalar"},
+                {
+                    "id": "price_history",
+                    "kind": "list",
+                    "cadence": {"target": 3},
+                },
+            ],
+            "targets": [
+                {
+                    "id": "fwd_excess_return_126d_vs_spy__@ticker:AACB",
+                    "kind": "scalar",
+                },
+                {
+                    "id": "fwd_excess_return_126d_vs_spy__@ticker:ZWS",
+                    "kind": "scalar",
+                },
+                {
+                    "id": "future_returns",
+                    "kind": "list",
+                    "cadence": {"target": 2},
+                },
+            ],
+        },
+    )
 
     feature_columns, target_columns = _schema_columns(SimpleNamespace(runtime=runtime))
 
     assert feature_columns == [
         "closing_price__@ticker:AACB",
         "closing_price__@ticker:ZWS",
+        "price_history",
     ]
     assert target_columns == [
         "fwd_excess_return_126d_vs_spy__@ticker:AACB",
         "fwd_excess_return_126d_vs_spy__@ticker:ZWS",
+        "future_returns",
     ]
+    flattened_features, flattened_targets = _schema_columns(
+        SimpleNamespace(runtime=runtime),
+        flatten_sequences=True,
+    )
+
+    assert flattened_features == [
+        "closing_price__@ticker:AACB",
+        "closing_price__@ticker:ZWS",
+        "price_history[0]",
+        "price_history[1]",
+        "price_history[2]",
+    ]
+    assert flattened_targets == [
+        "fwd_excess_return_126d_vs_spy__@ticker:AACB",
+        "fwd_excess_return_126d_vs_spy__@ticker:ZWS",
+        "future_returns[0]",
+        "future_returns[1]",
+    ]
+
+
+def test_torch_dataset_reads_flattened_sequence_columns(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    adapter = SimpleNamespace(
+        dataset=FeatureDatasetConfig(sample=SampleConfig(cadence="1h")),
+        iter_rows=lambda **_kwargs: [{"history[0]": 1.0, "history[1]": 2.0}],
+    )
+    monkeypatch.setattr(
+        torch_support.VectorAdapter,
+        "from_project",
+        lambda _path, output_id=None: adapter,
+    )
+    flatten_options = []
+
+    def schema_columns(_adapter, flatten_sequences=False):
+        flatten_options.append(flatten_sequences)
+        return ["history[0]", "history[1]"], []
+
+    monkeypatch.setattr(torch_support, "_schema_columns", schema_columns)
+
+    torch = ModuleType("torch")
+    torch.as_tensor = lambda values, **_kwargs: tuple(values)
+    torch.tensor = lambda values, **_kwargs: tuple(values)
+    torch_utils = ModuleType("torch.utils")
+    torch_data = ModuleType("torch.utils.data")
+    torch_data.Dataset = object
+    monkeypatch.setitem(sys.modules, "torch", torch)
+    monkeypatch.setitem(sys.modules, "torch.utils", torch_utils)
+    monkeypatch.setitem(sys.modules, "torch.utils.data", torch_data)
+
+    dataset = torch_support.torch_dataset(
+        tmp_path / "project.yaml",
+        flatten_sequences=True,
+    )
+
+    assert dataset[0] == (1.0, 2.0)
+    assert flatten_options == [True]
 
 
 def test_resolve_columns_excludes_partitioned_targets_from_features() -> None:

--- a/tests/unit/io/test_csv_writer.py
+++ b/tests/unit/io/test_csv_writer.py
@@ -1,4 +1,5 @@
 import csv
+import os
 
 from datapipeline.io.writers.csv_writer import CsvFileWriter
 
@@ -26,3 +27,21 @@ def test_csv_writer_honors_configured_encoding(tmp_path) -> None:
 
     raw = dest.read_bytes()
     assert raw.startswith(b"\xef\xbb\xbf")
+
+
+def test_csv_writer_disables_text_newline_translation(tmp_path, monkeypatch) -> None:
+    dest = tmp_path / "out.csv"
+    newlines = []
+    fdopen = os.fdopen
+
+    def recording_fdopen(fd, mode, *, encoding=None, newline=None):
+        newlines.append(newline)
+        return fdopen(fd, mode, encoding=encoding, newline=newline)
+
+    monkeypatch.setattr(os, "fdopen", recording_fdopen)
+
+    writer = CsvFileWriter(dest)
+    writer.write({"key": "k1"})
+    writer.close()
+
+    assert newlines == [""]

--- a/tests/unit/io/test_io_serializers.py
+++ b/tests/unit/io/test_io_serializers.py
@@ -100,6 +100,24 @@ def test_json_serializer_flat_view_emits_flattened_payload() -> None:
     assert payload == {"features.x": 1.0}
 
 
+def test_flat_json_serializer_rejects_colliding_sample_feature_ids() -> None:
+    serializer = json_line_serializer(view="flat")
+    sample = Sample(
+        key=("sample",),
+        features=Vector(values={"x": [10, 11], "x.0": 99}),
+    )
+
+    with pytest.raises(ValueError, match=r"features\.x\.0"):
+        serializer(sample)
+
+
+def test_csv_serializer_rejects_colliding_nested_fields() -> None:
+    serializer = csv_row_serializer()
+
+    with pytest.raises(ValueError, match=r"x\.0"):
+        serializer({"x": [10, 11], "x.0": 99})
+
+
 def test_json_serializer_raw_sample_emits_nested_payload() -> None:
     serializer = json_line_serializer(view="raw")
 

--- a/tests/unit/io/test_output_resolution.py
+++ b/tests/unit/io/test_output_resolution.py
@@ -70,6 +70,62 @@ def test_resolve_output_target_allows_dotted_filename_stem(tmp_path):
     )
 
 
+def test_routed_output_target_preserves_dotted_filename_stem(tmp_path):
+    base_dir = tmp_path / "outputs"
+    base_dir.mkdir()
+    cfg = ServeOutputConfig(
+        transport="fs",
+        format="jsonl",
+        directory=base_dir,
+        filename="equity.price_aware_universe",
+    )
+    target = resolve_output_target(
+        cli_output=None,
+        config_output=cfg,
+        default=None,
+        base_path=Path("."),
+        profile_name="processed",
+    )
+
+    routed_target = target.for_output("holdout.train")
+
+    assert (
+        routed_target.destination
+        == (
+            base_dir / "processed" / "equity.price_aware_universe.holdout.train.jsonl"
+        ).resolve()
+    )
+
+
+def test_feature_target_preserves_dotted_filename_stem(tmp_path):
+    base_dir = tmp_path / "outputs"
+    base_dir.mkdir()
+    cfg = ServeOutputConfig(
+        transport="fs",
+        format="jsonl",
+        directory=base_dir,
+        filename="equity.price_aware_universe",
+    )
+    target = resolve_output_target(
+        cli_output=None,
+        config_output=cfg,
+        default=None,
+        base_path=Path("."),
+        profile_name="preview",
+    )
+
+    feature_target = target.for_feature("equity.adv.daily.20")
+
+    assert (
+        feature_target.destination
+        == (
+            base_dir
+            / "preview"
+            / "equity.price_aware_universe.equity.adv.daily.20.jsonl"
+        ).resolve()
+    )
+
+
 def test_resolve_output_target_rejects_filename_with_selected_extension(tmp_path):
     base_dir = tmp_path / "outputs"
     base_dir.mkdir()

--- a/tests/unit/operations/test_persistence.py
+++ b/tests/unit/operations/test_persistence.py
@@ -168,6 +168,35 @@ def test_failed_runtime_write_preserves_existing_file(tmp_path) -> None:
     assert destination.read_text(encoding="utf-8") == "previous\n"
 
 
+def test_failed_runtime_write_closes_rows(tmp_path) -> None:
+    closed = False
+
+    def rows():
+        nonlocal closed
+        try:
+            yield {"value": object()}
+        finally:
+            closed = True
+
+    stream = rows()
+    target = OutputTarget(
+        transport="fs",
+        format="jsonl",
+        view="raw",
+        encoding="utf-8",
+        destination=tmp_path / "out.jsonl",
+    )
+
+    with pytest.raises(TypeError, match="Unsupported output value type"):
+        persist_runtime_result(
+            RuntimeOutput(rows=stream),
+            target=target,
+            logger=logging.getLogger(__name__),
+        )
+
+    assert closed
+
+
 def test_routed_runtime_output_rejects_colliding_destinations(tmp_path) -> None:
     targets = {
         output_id: OutputTarget(

--- a/tests/unit/operations/test_persistence.py
+++ b/tests/unit/operations/test_persistence.py
@@ -22,6 +22,7 @@ from datapipeline.operations.persistence import (
     ArtifactOutput,
     RoutedRuntimeOutput,
     RuntimeOutput,
+    RuntimeOutputBatch,
     persist_artifact_output,
     persist_runtime_result,
 )
@@ -33,6 +34,44 @@ class _CaptureHandler:
 
     def __call__(self, event) -> None:
         self.events.append(event)
+
+
+class _ClosableRows:
+    def __init__(
+        self,
+        rows=(),
+        *,
+        iteration_error: Exception | None = None,
+        close_error: Exception | None = None,
+    ) -> None:
+        self._rows = iter(rows)
+        self._iteration_error = iteration_error
+        self._close_error = close_error
+        self.closed = False
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self._iteration_error is not None:
+            raise self._iteration_error
+        return next(self._rows)
+
+    def close(self) -> None:
+        self.closed = True
+        if self._close_error is not None:
+            raise self._close_error
+
+
+class _IterFailureRows:
+    def __init__(self) -> None:
+        self.closed = False
+
+    def __iter__(self):
+        raise RuntimeError("iterator failed")
+
+    def close(self) -> None:
+        self.closed = True
 
 
 def test_persist_artifact_output_requires_declared_existing_file(tmp_path) -> None:
@@ -197,6 +236,161 @@ def test_failed_runtime_write_closes_rows(tmp_path) -> None:
     assert closed
 
 
+def test_runtime_writer_open_failure_closes_rows(monkeypatch, tmp_path) -> None:
+    rows = _ClosableRows()
+    target = OutputTarget(
+        transport="fs",
+        format="jsonl",
+        view="raw",
+        encoding="utf-8",
+        destination=tmp_path / "out.jsonl",
+    )
+
+    def fail_writer_open(_target):
+        raise OSError("open failed")
+
+    monkeypatch.setattr(persistence, "writer_factory", fail_writer_open)
+
+    with pytest.raises(OSError, match="open failed"):
+        persist_runtime_result(
+            RuntimeOutput(rows=rows),
+            target=target,
+            logger=logging.getLogger(__name__),
+        )
+
+    assert rows.closed
+
+
+def test_runtime_row_cleanup_failure_aborts_output(tmp_path) -> None:
+    destination = tmp_path / "out.jsonl"
+    destination.write_text("previous\n", encoding="utf-8")
+    rows = _ClosableRows(
+        ({"value": 1},),
+        close_error=OSError("cleanup failed"),
+    )
+    target = OutputTarget(
+        transport="fs",
+        format="jsonl",
+        view="raw",
+        encoding="utf-8",
+        destination=destination,
+    )
+
+    with pytest.raises(OSError, match="cleanup failed"):
+        persist_runtime_result(
+            RuntimeOutput(rows=rows),
+            target=target,
+            logger=logging.getLogger(__name__),
+        )
+
+    assert rows.closed
+    assert destination.read_text(encoding="utf-8") == "previous\n"
+
+
+def test_runtime_row_cleanup_does_not_replace_processing_failure(tmp_path) -> None:
+    rows = _ClosableRows(
+        iteration_error=RuntimeError("processing failed"),
+        close_error=OSError("cleanup failed"),
+    )
+    target = OutputTarget(
+        transport="fs",
+        format="jsonl",
+        view="raw",
+        encoding="utf-8",
+        destination=tmp_path / "out.jsonl",
+    )
+
+    with pytest.raises(RuntimeError, match="processing failed"):
+        persist_runtime_result(
+            RuntimeOutput(rows=rows),
+            target=target,
+            logger=logging.getLogger(__name__),
+        )
+
+    assert rows.closed
+
+
+def test_runtime_iterator_failure_closes_rows(tmp_path) -> None:
+    rows = _IterFailureRows()
+    target = OutputTarget(
+        transport="fs",
+        format="jsonl",
+        view="raw",
+        encoding="utf-8",
+        destination=tmp_path / "out.jsonl",
+    )
+
+    with pytest.raises(RuntimeError, match="iterator failed"):
+        persist_runtime_result(
+            RuntimeOutput(rows=rows),
+            target=target,
+            logger=logging.getLogger(__name__),
+        )
+
+    assert rows.closed
+
+
+def test_runtime_batch_failure_closes_pending_rows(tmp_path) -> None:
+    pending_rows = _ClosableRows()
+    target = OutputTarget(
+        transport="fs",
+        format="jsonl",
+        view="raw",
+        encoding="utf-8",
+        destination=tmp_path / "out.jsonl",
+    )
+    result = RuntimeOutputBatch(
+        outputs=(
+            RuntimeOutput(
+                rows=_ClosableRows(iteration_error=RuntimeError("processing failed")),
+                target=target,
+            ),
+            RuntimeOutput(rows=pending_rows, target=target),
+        )
+    )
+
+    with pytest.raises(RuntimeError, match="processing failed"):
+        persist_runtime_result(
+            result,
+            target=None,
+            logger=logging.getLogger(__name__),
+        )
+
+    assert pending_rows.closed
+
+
+def test_runtime_batch_callback_does_not_replace_persistence_failure(
+    tmp_path,
+) -> None:
+    target = OutputTarget(
+        transport="fs",
+        format="jsonl",
+        view="raw",
+        encoding="utf-8",
+        destination=tmp_path / "out.jsonl",
+    )
+
+    def fail_completion(_success: bool) -> None:
+        raise OSError("completion failed")
+
+    result = RuntimeOutputBatch(
+        outputs=(
+            RuntimeOutput(
+                rows=_ClosableRows(iteration_error=RuntimeError("processing failed")),
+                target=target,
+            ),
+        ),
+        on_complete=fail_completion,
+    )
+
+    with pytest.raises(RuntimeError, match="processing failed"):
+        persist_runtime_result(
+            result,
+            target=None,
+            logger=logging.getLogger(__name__),
+        )
+
+
 def test_routed_runtime_output_rejects_colliding_destinations(tmp_path) -> None:
     targets = {
         output_id: OutputTarget(
@@ -224,6 +418,23 @@ def test_routed_runtime_output_rejects_colliding_destinations(tmp_path) -> None:
         )
 
     assert list(tmp_path.iterdir()) == []
+
+
+def test_invalid_routed_runtime_output_closes_rows() -> None:
+    rows = _ClosableRows()
+
+    with pytest.raises(ValueError, match="at least one target"):
+        persist_runtime_result(
+            RoutedRuntimeOutput(
+                rows=rows,
+                targets={},
+                output_for_row=lambda _row: None,
+            ),
+            target=None,
+            logger=logging.getLogger(__name__),
+        )
+
+    assert rows.closed
 
 
 def test_runtime_persistence_emits_flat_output(tmp_path) -> None:
@@ -323,6 +534,31 @@ def test_runtime_persistence_reports_html_path(monkeypatch, tmp_path) -> None:
 
     assert destination.read_text(encoding="utf-8") == "<html></html>"
     assert results == [("Output", destination)]
+
+
+def test_html_output_cleanup_failure_prevents_commit(tmp_path) -> None:
+    destination = tmp_path / "matrix.html"
+    destination.write_text("previous", encoding="utf-8")
+    rows = _ClosableRows(close_error=OSError("cleanup failed"))
+
+    with pytest.raises(OSError, match="cleanup failed"):
+        persist_runtime_result(
+            RuntimeOutput(
+                rows=rows,
+                render_html=lambda: "replacement",
+            ),
+            target=OutputTarget(
+                transport="fs",
+                format="html",
+                view="flat",
+                encoding="utf-8",
+                destination=destination,
+            ),
+            logger=logging.getLogger(__name__),
+        )
+
+    assert rows.closed
+    assert destination.read_text(encoding="utf-8") == "previous"
 
 
 def test_failed_html_commit_preserves_existing_file(monkeypatch, tmp_path) -> None:

--- a/tests/unit/profiles/test_orchestration.py
+++ b/tests/unit/profiles/test_orchestration.py
@@ -991,6 +991,7 @@ def test_job_failure_marks_shared_run_failed(monkeypatch, tmp_path: Path) -> Non
 def test_latest_failure_still_finalizes_all_runs(
     monkeypatch,
     tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     task = OperationTask(id="pipeline", entrypoint="plugin.runtime")
     first = _run_paths(tmp_path / "first")
@@ -1017,14 +1018,16 @@ def test_latest_failure_still_finalizes_all_runs(
         latest.append(paths)
         if paths == first:
             raise OSError("latest failed")
+        raise OSError("second latest failed")
 
     monkeypatch.setattr(
         "datapipeline.profiles.orchestration.set_latest_run",
         set_latest,
     )
 
-    with pytest.raises(OSError, match="latest failed"):
-        run_profiles(request)
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(OSError, match="latest failed"):
+            run_profiles(request)
 
     metadata = [
         json.loads(paths.metadata_path.read_text(encoding="utf-8"))
@@ -1033,6 +1036,7 @@ def test_latest_failure_still_finalizes_all_runs(
     assert [item["status"] for item in metadata] == ["success", "success"]
     assert all(item["finished_at"] is not None for item in metadata)
     assert latest == [first, second]
+    assert "second latest failed" in caplog.text
 
 
 def test_later_output_commit_failure_marks_run_failed_and_preserves_latest(

--- a/tests/unit/profiles/test_orchestration.py
+++ b/tests/unit/profiles/test_orchestration.py
@@ -988,6 +988,53 @@ def test_job_failure_marks_shared_run_failed(monkeypatch, tmp_path: Path) -> Non
     assert failed == [run_paths]
 
 
+def test_latest_failure_still_finalizes_all_runs(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    task = OperationTask(id="pipeline", entrypoint="plugin.runtime")
+    first = _run_paths(tmp_path / "first")
+    second = _run_paths(tmp_path / "second")
+    request = _runtime_request(
+        tmp_path,
+        command="serve",
+        artifact_tasks=[],
+        jobs=[_runtime_job("serve", task, _runtime(tmp_path))],
+        serve_run_plans=(ServeRunPlan(first, None), ServeRunPlan(second, None)),
+    )
+    latest: list[RunPaths] = []
+
+    monkeypatch.setattr(
+        "datapipeline.profiles.orchestration.run_execution",
+        lambda _spec, work: work(),
+    )
+    monkeypatch.setattr(
+        "datapipeline.profiles.orchestration.execute_runtime_job",
+        lambda *_args: None,
+    )
+
+    def set_latest(paths: RunPaths) -> None:
+        latest.append(paths)
+        if paths == first:
+            raise OSError("latest failed")
+
+    monkeypatch.setattr(
+        "datapipeline.profiles.orchestration.set_latest_run",
+        set_latest,
+    )
+
+    with pytest.raises(OSError, match="latest failed"):
+        run_profiles(request)
+
+    metadata = [
+        json.loads(paths.metadata_path.read_text(encoding="utf-8"))
+        for paths in (first, second)
+    ]
+    assert [item["status"] for item in metadata] == ["success", "success"]
+    assert all(item["finished_at"] is not None for item in metadata)
+    assert latest == [first, second]
+
+
 def test_later_output_commit_failure_marks_run_failed_and_preserves_latest(
     monkeypatch,
     tmp_path: Path,

--- a/tests/unit/services/test_operation_and_profile_loading.py
+++ b/tests/unit/services/test_operation_and_profile_loading.py
@@ -1236,6 +1236,18 @@ def test_nested_profile_files_are_rejected(tmp_path):
         _serve_profiles(project_yaml)
 
 
+def test_profile_filename_rejects_reserved_path_component(tmp_path):
+    project_yaml = _write_project(tmp_path, operations_ref="operations")
+    profiles_root = _profiles_dir(project_yaml)
+    (profiles_root / "inspect....yaml").write_text(
+        "operation: coverage\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="profile name must not be"):
+        _inspect_profiles(project_yaml)
+
+
 def test_profile_command_cannot_override_filename(tmp_path):
     project_yaml = _write_project(tmp_path, operations_ref="operations")
     build_dir = _profile_kind_dir(project_yaml)

--- a/tests/unit/services/test_pipeline_definition.py
+++ b/tests/unit/services/test_pipeline_definition.py
@@ -510,7 +510,7 @@ def test_scaling_policy_does_not_invalidate_raw_vector_inputs(tmp_path: Path) ->
     )
 
 
-def test_scaler_hash_tracks_fold_training_population_only(tmp_path: Path) -> None:
+def test_scaler_hash_tracks_every_fold_role(tmp_path: Path) -> None:
     definition = load_pipeline(_write_pipeline(tmp_path))
     streams = _single_stream_catalog()
     feature = FeatureRecordConfig(
@@ -529,8 +529,6 @@ def test_scaler_hash_tracks_fold_training_population_only(tmp_path: Path) -> Non
             DatasetFold(
                 id="holdout",
                 train=["train"],
-                validation=["validation"],
-                test=["test"],
             )
         ],
     )
@@ -539,7 +537,7 @@ def test_scaler_hash_tracks_fold_training_population_only(tmp_path: Path) -> Non
         features=[feature],
         split=split,
     )
-    publication_changed = baseline.model_copy(
+    validation_changed = baseline.model_copy(
         update={
             "split": split.model_copy(
                 update={
@@ -547,7 +545,22 @@ def test_scaler_hash_tracks_fold_training_population_only(tmp_path: Path) -> Non
                         DatasetFold(
                             id="holdout",
                             train=["train"],
-                            validation=["validation", "test"],
+                            validation=["validation"],
+                        )
+                    ]
+                }
+            )
+        }
+    )
+    test_changed = baseline.model_copy(
+        update={
+            "split": split.model_copy(
+                update={
+                    "folds": [
+                        DatasetFold(
+                            id="holdout",
+                            train=["train"],
+                            test=["test"],
                         )
                     ]
                 }
@@ -578,7 +591,8 @@ def test_scaler_hash_tracks_fold_training_population_only(tmp_path: Path) -> Non
             (ScalerTask(),),
         ).for_artifact(SCALER_STATISTICS)
 
-    assert scaler_hash(publication_changed) == scaler_hash(baseline)
+    assert scaler_hash(validation_changed) != scaler_hash(baseline)
+    assert scaler_hash(test_changed) != scaler_hash(baseline)
     assert scaler_hash(training_changed) != scaler_hash(baseline)
 
 

--- a/tests/unit/services/test_scaffold_entrypoints.py
+++ b/tests/unit/services/test_scaffold_entrypoints.py
@@ -1,5 +1,9 @@
+import subprocess
+import sys
+import time
 import tomllib
 from pathlib import Path
+from textwrap import dedent
 
 import pytest
 from tomlkit.exceptions import ParseError
@@ -9,6 +13,101 @@ from datapipeline.services.scaffold.entrypoints import (
     read_entry_points,
     register_entry_point,
 )
+from datapipeline.services.scaffold.locking import acquire_scaffold_lock
+
+
+def test_register_entry_point_serializes_concurrent_writers(tmp_path: Path) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text("[project]\nname = 'example'\n", encoding="utf-8")
+    ready = tmp_path / "ready"
+    go = tmp_path / "go"
+    blocked = tmp_path / "blocked"
+    entered_update = tmp_path / "entered-update"
+    source_root = Path(__file__).parents[3] / "src"
+    script = dedent(
+        """
+        import sys
+        import time
+        from pathlib import Path
+
+        sys.path.insert(0, sys.argv[1])
+
+        import datapipeline.services.scaffold.entrypoints as entrypoints
+        import datapipeline.services.execution_lock as execution_lock
+
+        original_update = entrypoints._register_entry_point
+        original_try_lock = execution_lock.try_acquire_file_lock
+
+        def marked_update(*args, **kwargs):
+            Path(sys.argv[6]).touch()
+            return original_update(*args, **kwargs)
+
+        def marked_try_lock(lock_file):
+            acquired = original_try_lock(lock_file)
+            if not acquired:
+                Path(sys.argv[5]).touch()
+            return acquired
+
+        entrypoints._register_entry_point = marked_update
+        execution_lock.try_acquire_file_lock = marked_try_lock
+        Path(sys.argv[3]).touch()
+        while not Path(sys.argv[4]).exists():
+            time.sleep(0.01)
+        entrypoints.register_entry_point(
+            Path(sys.argv[2]),
+            "datapipeline.parsers",
+            "second",
+            "package:second",
+        )
+        """
+    )
+    command = [
+        sys.executable,
+        "-c",
+        script,
+        str(source_root),
+        str(pyproject),
+        str(ready),
+        str(go),
+        str(blocked),
+        str(entered_update),
+    ]
+
+    with acquire_scaffold_lock(tmp_path) as scaffold_lock:
+        process = subprocess.Popen(command)
+        try:
+            deadline = time.monotonic() + 10
+            while not ready.exists() and time.monotonic() < deadline:
+                time.sleep(0.01)
+            assert ready.exists()
+            go.touch()
+            deadline = time.monotonic() + 10
+            while not blocked.exists() and time.monotonic() < deadline:
+                time.sleep(0.01)
+            assert blocked.exists()
+            assert not entered_update.exists()
+            register_entry_point(
+                pyproject,
+                PARSERS_EP,
+                "first",
+                "package:first",
+                scaffold_lock=scaffold_lock,
+            )
+        except BaseException:
+            process.terminate()
+            process.wait(timeout=10)
+            raise
+
+    try:
+        assert process.wait(timeout=10) == 0
+    finally:
+        if process.poll() is None:
+            process.terminate()
+            process.wait(timeout=10)
+    assert read_entry_points(pyproject, PARSERS_EP) == {
+        "first": "package:first",
+        "second": "package:second",
+    }
 
 
 def test_register_entry_point_preserves_unrelated_toml(tmp_path: Path) -> None:
@@ -211,3 +310,11 @@ def test_register_entry_point_rejects_malformed_toml(tmp_path: Path) -> None:
 
     with pytest.raises(ParseError):
         register_entry_point(pyproject, PARSERS_EP, "parser", "package:parser")
+
+    pyproject.write_text("[project]\nname = 'example'\n", encoding="utf-8")
+    assert register_entry_point(
+        pyproject,
+        PARSERS_EP,
+        "parser",
+        "package:parser",
+    )

--- a/tests/unit/services/test_scaffold_python.py
+++ b/tests/unit/services/test_scaffold_python.py
@@ -17,6 +17,18 @@ def _plugin_with_invalid_pyproject(tmp_path: Path) -> Path:
     return plugin
 
 
+def _valid_plugin(tmp_path: Path) -> Path:
+    plugin = tmp_path / "plugin"
+    package = plugin / "src" / "plugin"
+    package.mkdir(parents=True)
+    (package / "__init__.py").touch()
+    (plugin / "pyproject.toml").write_text(
+        "[project]\nname = 'plugin'\n",
+        encoding="utf-8",
+    )
+    return plugin
+
+
 def test_loader_validates_pyproject_before_creating_files(tmp_path: Path) -> None:
     plugin = _plugin_with_invalid_pyproject(tmp_path)
 
@@ -69,3 +81,26 @@ def test_loader_rejects_python_keyword_name(tmp_path: Path) -> None:
         create_loader(name="class", root=plugin)
 
     assert not (package / "loaders").exists()
+
+
+def test_loader_removes_created_files_when_registration_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    plugin = _valid_plugin(tmp_path)
+    pyproject = plugin / "pyproject.toml"
+    original = pyproject.read_bytes()
+
+    def fail_write(*args, **kwargs):
+        raise OSError("write failed")
+
+    monkeypatch.setattr(
+        "datapipeline.services.scaffold.entrypoints._write_document",
+        fail_write,
+    )
+
+    with pytest.raises(OSError, match="write failed"):
+        create_loader(name="WeatherLoader", root=plugin)
+
+    assert not (plugin / "src" / "plugin" / "loaders").exists()
+    assert pyproject.read_bytes() == original

--- a/tests/unit/services/test_stream_plan.py
+++ b/tests/unit/services/test_stream_plan.py
@@ -89,6 +89,46 @@ def test_invalid_source_id_fails_before_project_mutation(monkeypatch, tmp_path) 
         execute_stream_plan(plan)
 
 
+def test_existing_project_with_missing_config_dirs_can_be_scaffolded(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    _patch_project(monkeypatch, tmp_path)
+    project_yaml = tmp_path / "project.yaml"
+    project_yaml.write_text(
+        "schema_version: 2\n"
+        "artifact_revision: 1\n"
+        "name: default\n"
+        "paths:\n"
+        "  streams: ./streams\n"
+        "  sources: ./sources\n"
+        "  dataset: dataset.yaml\n"
+        "  artifacts: ./artifacts\n"
+        "  profiles: ./profiles\n"
+        "globals: {}\n",
+        encoding="utf-8",
+    )
+    plan = StreamPlan(
+        project_yaml=project_yaml,
+        stream_id="weather.weather",
+        root=tmp_path,
+        source=SourceCreation(
+            source_id="demo.weather",
+            loader_entrypoint="custom.loader",
+            loader_args={},
+            parser=ParserReference("identity"),
+        ),
+        mapper=MapperReference("identity"),
+        domain=DomainReference("weather"),
+        dto_to_create=None,
+    )
+
+    result = execute_stream_plan(plan)
+
+    assert result.path == tmp_path / "streams" / "weather.weather.yaml"
+    assert (tmp_path / "sources" / "demo.weather.yaml").exists()
+
+
 def test_existing_source_fails_before_creating_planned_components(
     monkeypatch,
     tmp_path: Path,
@@ -97,8 +137,22 @@ def test_existing_source_fails_before_creating_planned_components(
     original_pyproject = pyproject.read_bytes()
     project_yaml = tmp_path / "project.yaml"
     project = ensure_project_scaffold(project_yaml)
-    source_path = project.source_dirs[0] / "nasa.weather.yaml"
-    source_path.write_text("existing source\n", encoding="utf-8")
+    common_sources = tmp_path / "common" / "sources"
+    common_sources.mkdir(parents=True)
+    project_yaml.write_text(
+        project_yaml.read_text(encoding="utf-8").replace(
+            "  sources: ./sources",
+            "  sources: [./sources, ./common/sources]",
+        ),
+        encoding="utf-8",
+    )
+    source_path = common_sources / "existing.yaml"
+    source_path.write_text(
+        "id: nasa.weather\n"
+        "parser: {entrypoint: identity}\n"
+        "loader: {entrypoint: identity}\n",
+        encoding="utf-8",
+    )
     dto = PythonType("WeatherDTO", "example.dtos.weather_dto")
     plan = StreamPlan(
         project_yaml=project_yaml,
@@ -115,12 +169,12 @@ def test_existing_source_fails_before_creating_planned_components(
         dto_to_create="WeatherDTO",
     )
 
-    with pytest.raises(FileExistsError, match="nasa.weather.yaml"):
+    with pytest.raises(FileExistsError, match="Source id 'nasa.weather'"):
         execute_stream_plan(plan)
 
     assert not (tmp_path / "src").exists()
     assert not (project.stream_dirs[0] / "weather.weather.yaml").exists()
-    assert source_path.read_text(encoding="utf-8") == "existing source\n"
+    assert "id: nasa.weather" in source_path.read_text(encoding="utf-8")
     assert pyproject.read_bytes() == original_pyproject
 
 
@@ -132,8 +186,22 @@ def test_existing_stream_fails_before_creating_planned_components(
     original_pyproject = pyproject.read_bytes()
     project_yaml = tmp_path / "project.yaml"
     project = ensure_project_scaffold(project_yaml)
-    stream_path = project.stream_dirs[0] / "weather.weather.yaml"
-    stream_path.write_text("existing stream\n", encoding="utf-8")
+    common_streams = tmp_path / "common" / "streams"
+    common_streams.mkdir(parents=True)
+    project_yaml.write_text(
+        project_yaml.read_text(encoding="utf-8").replace(
+            "  streams: ./streams",
+            "  streams: [./streams, ./common/streams]",
+        ),
+        encoding="utf-8",
+    )
+    stream_path = common_streams / "existing.yaml"
+    stream_path.write_text(
+        "id: weather.weather\n"
+        "from: {source: nasa.weather}\n"
+        "map: {entrypoint: identity}\n",
+        encoding="utf-8",
+    )
     dto = PythonType("WeatherDTO", "example.dtos.weather_dto")
     plan = StreamPlan(
         project_yaml=project_yaml,
@@ -150,12 +218,12 @@ def test_existing_stream_fails_before_creating_planned_components(
         dto_to_create="WeatherDTO",
     )
 
-    with pytest.raises(FileExistsError, match="weather.weather.yaml"):
+    with pytest.raises(FileExistsError, match="Stream id 'weather.weather'"):
         execute_stream_plan(plan)
 
     assert not (tmp_path / "src").exists()
     assert not (project.source_dirs[0] / "nasa.weather.yaml").exists()
-    assert stream_path.read_text(encoding="utf-8") == "existing stream\n"
+    assert "id: weather.weather" in stream_path.read_text(encoding="utf-8")
     assert pyproject.read_bytes() == original_pyproject
 
 
@@ -207,10 +275,10 @@ def test_creation_plan_executes_exact_declared_components(
     mapper_call: dict[str, object] = {}
     stream_call: dict[str, object] = {}
 
-    def create_domain(domain, root):
+    def create_domain(domain, root, **kwargs):
         order.append("domain")
 
-    def create_dto(name, root):
+    def create_dto(name, root, **kwargs):
         order.append("dto")
 
     def create_parser(**kwargs):
@@ -332,7 +400,7 @@ def test_dto_creation_is_a_single_explicit_plan_action(monkeypatch, tmp_path) ->
 
     monkeypatch.setattr(
         "datapipeline.services.scaffold.stream_plan.create_dto",
-        lambda name, root: created_dto.update(name=name, root=root),
+        lambda name, root, **kwargs: created_dto.update(name=name, root=root),
     )
     monkeypatch.setattr(
         "datapipeline.services.scaffold.stream_plan.create_mapper",
@@ -359,3 +427,55 @@ def test_dto_creation_is_a_single_explicit_plan_action(monkeypatch, tmp_path) ->
 
     assert created_dto["name"] == "WeatherDTO"
     assert mapper_call["input_module"] == "example.dtos.weather_dto"
+
+
+def test_stream_plan_rolls_back_after_late_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    plugin = tmp_path / "plugin"
+    package = plugin / "src" / "example"
+    package.mkdir(parents=True)
+    (package / "__init__.py").touch()
+    pyproject = plugin / "pyproject.toml"
+    pyproject.write_text("[project]\nname = 'example'\n", encoding="utf-8")
+    original_pyproject = pyproject.read_bytes()
+    project_yaml = plugin / "your-dataset" / "project.yaml"
+    dto = PythonType("WeatherDTO", "example.dtos.weather_dto")
+    plan = StreamPlan(
+        project_yaml=project_yaml,
+        stream_id="weather.hourly",
+        root=plugin,
+        source=SourceCreation(
+            source_id="nasa.weather",
+            loader_entrypoint="custom.loader",
+            loader_args={},
+            parser=ParserCreation("WeatherParser", dto),
+        ),
+        mapper=MapperCreation("map_weather", dto),
+        domain=DomainCreation("weather"),
+        dto_to_create="WeatherDTO",
+    )
+
+    def fail_stream_write(**kwargs):
+        raise OSError("stream write failed")
+
+    monkeypatch.setattr(
+        "datapipeline.services.scaffold.stream_plan.write_source_stream",
+        fail_stream_write,
+    )
+
+    with pytest.raises(OSError, match="stream write failed"):
+        execute_stream_plan(plan)
+
+    assert pyproject.read_bytes() == original_pyproject
+    assert (package / "__init__.py").exists()
+    assert not (package / "domains").exists()
+    assert not (package / "dtos").exists()
+    assert not (package / "parsers").exists()
+    assert not (package / "mappers").exists()
+    assert not project_yaml.exists()
+    assert not (project_yaml.parent / ".env.example").exists()
+    assert not (project_yaml.parent / "sources").exists()
+    assert not (project_yaml.parent / "streams").exists()
+    assert not (project_yaml.parent / "profiles").exists()

--- a/tests/unit/services/test_stream_yaml.py
+++ b/tests/unit/services/test_stream_yaml.py
@@ -85,6 +85,62 @@ def test_aligned_stream_refuses_to_replace_existing_config(tmp_path: Path) -> No
     assert path.read_text(encoding="utf-8") == "existing\n"
 
 
+def test_stream_scaffold_rejects_existing_id_in_another_root(tmp_path: Path) -> None:
+    project_yaml = tmp_path / "project.yaml"
+    project = ensure_project_scaffold(project_yaml)
+    common_streams = tmp_path / "common" / "streams"
+    common_streams.mkdir(parents=True)
+    project_yaml.write_text(
+        project_yaml.read_text(encoding="utf-8").replace(
+            "  streams: ./streams",
+            "  streams: [./streams, ./common/streams]",
+        ),
+        encoding="utf-8",
+    )
+    (common_streams / "existing.yaml").write_text(
+        "id: prices.daily\n"
+        "from: {source: provider.prices}\n"
+        "map: {entrypoint: identity}\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(FileExistsError, match="Stream id 'prices.daily'"):
+        write_source_stream(
+            project_yaml,
+            "prices.daily",
+            "provider.prices",
+            "identity",
+        )
+
+    assert not (project.stream_dirs[0] / "prices.daily.yaml").exists()
+
+
+def test_stream_scaffold_does_not_validate_unrelated_stream_values(
+    tmp_path: Path,
+) -> None:
+    project_yaml = tmp_path / "project.yaml"
+    project = ensure_project_scaffold(project_yaml)
+    (project_yaml.parent / ".env").write_text(
+        "SECRET=TOP-SECRET-VALUE\n",
+        encoding="utf-8",
+    )
+    (project.stream_dirs[0] / "existing.yaml").write_text(
+        "id: prices.existing\n"
+        "from: {source: '${env:SECRET}'}\n"
+        "map: {entrypoint: identity}\n",
+        encoding="utf-8",
+    )
+
+    path = write_source_stream(
+        project_yaml,
+        "prices.daily",
+        "provider.prices",
+        "identity",
+    )
+
+    assert path.name == "prices.daily.yaml"
+
+
 def test_stream_scaffolds_render_valid_configs(tmp_path: Path) -> None:
     project_yaml = tmp_path / "project.yaml"
 
@@ -109,3 +165,34 @@ def test_stream_scaffolds_render_valid_configs(tmp_path: Path) -> None:
     )
     assert source.id == "prices.daily-us"
     assert aligned.from_.align == ("prices.bid", "prices.ask")
+
+
+def test_stream_scaffolds_quote_yaml_sensitive_strings(tmp_path: Path) -> None:
+    project_yaml = tmp_path / "project.yaml"
+
+    source_path = write_source_stream(
+        project_yaml,
+        "null",
+        "null",
+        "null",
+    )
+    aligned_path = write_aligned_stream(
+        project_yaml,
+        "yes",
+        ["null", "off"],
+        "null",
+    )
+
+    source = SourceStreamConfig.model_validate(
+        yaml.safe_load(source_path.read_text(encoding="utf-8"))
+    )
+    aligned = AlignedStreamConfig.model_validate(
+        yaml.safe_load(aligned_path.read_text(encoding="utf-8"))
+    )
+
+    assert source.id == "null"
+    assert source.from_.source == "null"
+    assert source.map.entrypoint == "null"
+    assert aligned.id == "yes"
+    assert aligned.from_.align == ("null", "off")
+    assert aligned.combine.entrypoint == "null"

--- a/tests/unit/test_record.py
+++ b/tests/unit/test_record.py
@@ -1,0 +1,14 @@
+from datetime import datetime, timedelta, tzinfo
+
+import pytest
+
+from datapipeline.domain.record import TemporalRecord
+
+
+def test_temporal_record_rejects_timezone_without_utc_offset() -> None:
+    class MissingOffsetTimezone(tzinfo):
+        def utcoffset(self, dt: datetime | None) -> timedelta | None:
+            return None
+
+    with pytest.raises(ValueError, match="time must be timezone-aware"):
+        TemporalRecord(datetime(2024, 1, 1, tzinfo=MissingOffsetTimezone()))


### PR DESCRIPTION
## Summary

- fixes concrete data and cache correctness issues around scaler freshness, flattened outputs, tick grids, UTC datetimes, reserved output paths, and Torch sequence schemas
- preserves primary pipeline failures and makes runtime output ownership, cleanup, abort, and serve-run finalization explicit
- serializes scaffold mutations across processes and rolls back partial composite scaffolds and entry-point changes
- tightens source/template generation, secret-safe validation reporting, filename handling, CSV newline behavior, and progress presentation

## Why

Several independent edge cases could reuse stale artifacts, flatten colliding fields, conceal the original processing error, leave runtime resources open, or leave partially generated scaffold state. Concurrent scaffold commands could also race while updating `pyproject.toml` or rolling back shared paths.

The fixes keep these responsibilities explicit: validation rejects ambiguous states early, runtime writers and row iterators have clear ownership, and scaffold commands use one cross-process lock with scoped rollback.

## Impact

This is a v5.0.7 patch release. No intentional project-config migration is required. Existing successful pipeline behavior is preserved; corrected edge cases now fail explicitly or produce the intended schema/output.

## Validation

- `ruff format --check .`
- `ruff check .`
- `mypy --config-file pyproject.toml`
- `pytest -q -W error` — 1,593 passed
- `git diff --check`
